### PR TITLE
feat(web): add cattle status management

### DIFF
--- a/apps/web/src/features/cattle/detail/actions.ts
+++ b/apps/web/src/features/cattle/detail/actions.ts
@@ -2,7 +2,7 @@
 
 import { createDemoResponse, isDemo } from "@/lib/api-client";
 import { verifyAndGetUserId } from "@/lib/jwt";
-import { DeleteCattle } from "@/services/cattleService";
+import { DeleteCattle, updateCattleStatus } from "@/services/cattleService";
 import { redirect } from "next/navigation";
 
 export async function deleteCattleAction(cattleId: number) {
@@ -29,5 +29,30 @@ export async function deleteCattleAction(cattleId: number) {
 			success: false,
 			error: "牛の削除に失敗しました",
 		};
+	}
+}
+
+export async function updateCattleStatusAction(
+	cattleId: number,
+	status: "HEALTHY" | "PREGNANT" | "RESTING" | "TREATING",
+	reason?: string,
+) {
+	try {
+		const userId = await verifyAndGetUserId();
+		if (isDemo(userId)) {
+			return createDemoResponse(true);
+		}
+
+		await updateCattleStatus(cattleId, status, reason);
+		return { success: true } as const;
+	} catch (error) {
+		console.error("Failed to update status:", error);
+		if (
+			error instanceof Error &&
+			(error.message.includes("401") || error.message.includes("403"))
+		) {
+			redirect("/login");
+		}
+		return { success: false, error: "ステータスの更新に失敗しました" } as const;
 	}
 }

--- a/apps/web/src/features/cattle/detail/components/__tests__/header.test.tsx
+++ b/apps/web/src/features/cattle/detail/components/__tests__/header.test.tsx
@@ -23,6 +23,7 @@ vi.mock("sonner", () => ({
 // Mock the delete action
 vi.mock("../../actions", () => ({
 	deleteCattleAction: vi.fn(),
+	updateCattleStatusAction: vi.fn(),
 }));
 
 // Mock getGrowthStage utility

--- a/apps/web/src/features/cattle/detail/components/__tests__/status-badge.test.tsx
+++ b/apps/web/src/features/cattle/detail/components/__tests__/status-badge.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { StatusBadge } from "../status-badge";
+
+vi.mock("../../actions", () => ({
+	updateCattleStatusAction: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe("StatusBadge", () => {
+	beforeAll(() => {
+		// jsdom lacks pointer capture APIs used by Radix Select
+		// @ts-ignore
+		window.HTMLElement.prototype.hasPointerCapture = () => {};
+		// @ts-ignore
+		window.HTMLElement.prototype.releasePointerCapture = () => {};
+	});
+	it("opens dialog and submits status", async () => {
+		const user = userEvent.setup();
+		const { updateCattleStatusAction } = await import("../../actions");
+		vi.mocked(updateCattleStatusAction).mockResolvedValue({ success: true });
+
+		render(<StatusBadge cattleId={1} status="健康" />);
+
+		await user.click(screen.getByText("健康"));
+		await user.click(screen.getByRole("button", { name: "保存" }));
+
+		expect(updateCattleStatusAction).toHaveBeenCalledWith(
+			1,
+			"HEALTHY",
+			undefined,
+		);
+	});
+});

--- a/apps/web/src/features/cattle/detail/components/hedear.tsx
+++ b/apps/web/src/features/cattle/detail/components/hedear.tsx
@@ -20,6 +20,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import { deleteCattleAction } from "../actions";
+import { StatusBadge } from "./status-badge";
 
 type CattleDetailHeaderProps = {
 	cattle: GetCattleDetailResType;
@@ -107,7 +108,10 @@ export function CattleDetailHeader({ cattle }: CattleDetailHeaderProps) {
 						</span>
 					</Badge>
 					<Badge>{getGrowthStage(cattle.growthStage)}</Badge>
-					<Badge variant="outline">{cattle.healthStatus}</Badge>
+					<StatusBadge
+						cattleId={cattle.cattleId}
+						status={cattle.healthStatus}
+					/>
 				</div>
 				<p className="text-xs">耳標番号：{cattle.earTagNumber}</p>
 			</div>

--- a/apps/web/src/features/cattle/detail/components/status-badge.tsx
+++ b/apps/web/src/features/cattle/detail/components/status-badge.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import classNames from "classnames";
+import { useState } from "react";
+import { toast } from "sonner";
+import { updateCattleStatusAction } from "../actions";
+
+const statusOptions = [
+	{ value: "HEALTHY", label: "健康" },
+	{ value: "PREGNANT", label: "妊娠中" },
+	{ value: "RESTING", label: "休息中" },
+	{ value: "TREATING", label: "治療中" },
+];
+
+interface StatusBadgeProps {
+	cattleId: number;
+	status: string;
+}
+
+export function StatusBadge({ cattleId, status }: StatusBadgeProps) {
+	const [open, setOpen] = useState(false);
+	const [selectedStatus, setSelectedStatus] = useState<string>(
+		statusOptions.find((opt) => opt.label === status)?.value ?? "HEALTHY",
+	);
+	const [reason, setReason] = useState("");
+	const [loading, setLoading] = useState(false);
+
+	const colorClass = classNames("transition-all duration-200", {
+		"border-blue-500 text-blue-500": status === "健康",
+		"border-yellow-500 text-yellow-500": status === "妊娠中",
+		"border-green-500 text-green-500": status === "休息中",
+		"border-red-500 text-red-500": status === "治療中",
+	});
+
+	const handleSave = async () => {
+		setLoading(true);
+		try {
+			const result = await updateCattleStatusAction(
+				cattleId,
+				selectedStatus as StatusBadgeProps["status"],
+				reason || undefined,
+			);
+			if (result.success) {
+				toast.success("ステータスを更新しました");
+			} else {
+				toast.error(result.error || "ステータスの更新に失敗しました");
+			}
+			setOpen(false);
+		} catch (e) {
+			toast.error("ステータスの更新に失敗しました");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<>
+			<Badge variant="outline" className={colorClass} asChild>
+				<button type="button" onClick={() => setOpen(true)}>
+					{status}
+				</button>
+			</Badge>
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>ステータスを変更</DialogTitle>
+						<DialogDescription>
+							新しいステータスと理由を入力してください
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-4">
+						<Select value={selectedStatus} onValueChange={setSelectedStatus}>
+							<SelectTrigger>
+								<SelectValue placeholder="ステータスを選択" />
+							</SelectTrigger>
+							<SelectContent>
+								{statusOptions.map((opt) => (
+									<SelectItem key={opt.value} value={opt.value}>
+										{opt.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Textarea
+							placeholder="理由（任意）"
+							value={reason}
+							onChange={(e) => setReason(e.target.value)}
+						/>
+					</div>
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => setOpen(false)}
+							disabled={loading}
+						>
+							キャンセル
+						</Button>
+						<Button onClick={handleSave} disabled={loading}>
+							保存
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/apps/web/src/features/cattle/list/__tests__/container.test.tsx
+++ b/apps/web/src/features/cattle/list/__tests__/container.test.tsx
@@ -69,7 +69,26 @@ describe("CattleListContainer", () => {
 		expect(screen.getByText("テスト牛2")).toBeInTheDocument();
 		expect(screen.getByText("耳標番号：1234")).toBeInTheDocument();
 		expect(screen.getByText("耳標番号：1235")).toBeInTheDocument();
-		expect(cattleService.GetCattleList).toHaveBeenCalledWith({});
+		expect(cattleService.GetCattleList).toHaveBeenCalledWith({
+			cursor: undefined,
+			limit: undefined,
+			sort_by: undefined,
+			sort_order: undefined,
+			search: undefined,
+			growth_stage: undefined,
+			gender: undefined,
+			status: undefined,
+		});
+	});
+
+	it("should pass status param", async () => {
+		vi.mocked(cattleService.GetCattleList).mockResolvedValue(mockCattleList);
+		await CattleListContainer({
+			searchParams: Promise.resolve({ status: "HEALTHY" }),
+		});
+		expect(cattleService.GetCattleList).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "HEALTHY" }),
+		);
 	});
 
 	it("should handle API error correctly", async () => {

--- a/apps/web/src/features/cattle/list/__tests__/presentational.test.tsx
+++ b/apps/web/src/features/cattle/list/__tests__/presentational.test.tsx
@@ -97,6 +97,7 @@ describe("CattleListPresentation", () => {
 		mockSearchParams.delete("search");
 		mockSearchParams.delete("growth_stage");
 		mockSearchParams.delete("gender");
+		mockSearchParams.delete("status");
 		mockSearchParams.delete("sort_by");
 		mockSearchParams.delete("sort_order");
 
@@ -170,20 +171,26 @@ describe("CattleListPresentation", () => {
 		// 成長段階のドロップダウンを開く
 		await user.click(screen.getByRole("button", { name: "成長段階を選択" }));
 
-		// 仔牛を選択（Command内のオプション）
+		// 仔牛を選択
 		await user.click(screen.getByRole("option", { name: "仔牛" }));
 
 		// 性別のドロップダウンを開く
 		await user.click(screen.getByRole("button", { name: "性別を選択" }));
 
-		// オスを選択（Command内のオプション）
+		// オスを選択
 		await user.click(screen.getByRole("option", { name: "オス" }));
+
+		// ステータスのドロップダウンを開く
+		await user.click(screen.getByRole("button", { name: "ステータスを選択" }));
+
+		// 健康を選択
+		await user.click(screen.getByRole("option", { name: "健康" }));
 
 		// 絞り込みを適用
 		await user.click(screen.getByRole("button", { name: "絞り込む" }));
 
 		expect(mockPush).toHaveBeenCalledWith(
-			"/cattle?growth_stage=CALF&gender=%E3%82%AA%E3%82%B9",
+			"/cattle?growth_stage=CALF&gender=%E3%82%AA%E3%82%B9&status=HEALTHY",
 		);
 	});
 
@@ -191,6 +198,7 @@ describe("CattleListPresentation", () => {
 		const user = userEvent.setup();
 		mockSearchParams.set("growth_stage", "CALF");
 		mockSearchParams.set("gender", "オス");
+		mockSearchParams.set("status", "HEALTHY");
 
 		render(<CattleListPresentation cattleList={mockCattleList} />);
 

--- a/apps/web/src/features/cattle/list/components/FilterSheet.tsx
+++ b/apps/web/src/features/cattle/list/components/FilterSheet.tsx
@@ -30,11 +30,18 @@ import classNames from "classnames";
 import { Check, ChevronsUpDown, Filter, X } from "lucide-react";
 import { memo, useState } from "react";
 import { useForm } from "react-hook-form";
-import { type FilterFormData, FormSchema, filterOptions } from "../constants";
+import {
+	type FilterFormData,
+	FormSchema,
+	genderOptions,
+	growthStageOptions,
+	statusOptions,
+} from "../constants";
 
 interface FilterSheetProps {
 	initialGrowthStage: string[];
 	initialGender: string[];
+	initialStatus: string[];
 	onSubmit: (data: FilterFormData) => void;
 	onClear: () => void;
 }
@@ -43,17 +50,20 @@ export const FilterSheet = memo(
 	({
 		initialGrowthStage,
 		initialGender,
+		initialStatus,
 		onSubmit,
 		onClear,
 	}: FilterSheetProps) => {
 		const [growthStageOpen, setGrowthStageOpen] = useState(false);
 		const [genderOpen, setGenderOpen] = useState(false);
+		const [statusOpen, setStatusOpen] = useState(false);
 
 		const form = useForm<FilterFormData>({
 			resolver: zodResolver(FormSchema),
 			defaultValues: {
 				growth_stage: initialGrowthStage,
 				gender: initialGender,
+				status: initialStatus,
 			},
 		});
 
@@ -87,10 +97,26 @@ export const FilterSheet = memo(
 			);
 		};
 
+		const addStatus = (status: string) => {
+			const currentValues = form.getValues("status");
+			if (!currentValues.includes(status)) {
+				form.setValue("status", [...currentValues, status]);
+			}
+		};
+
+		const removeStatus = (status: string) => {
+			const currentValues = form.getValues("status");
+			form.setValue(
+				"status",
+				currentValues.filter((s) => s !== status),
+			);
+		};
+
 		const handleClear = () => {
 			form.reset({
 				growth_stage: [],
 				gender: [],
+				status: [],
 			});
 			onClear();
 		};
@@ -99,7 +125,7 @@ export const FilterSheet = memo(
 			const selected = form.watch("growth_stage");
 			if (selected.length === 0) return "成長段階を選択";
 			if (selected.length === 1) {
-				const option = filterOptions.find((opt) => opt.id === selected[0]);
+				const option = growthStageOptions.find((opt) => opt.id === selected[0]);
 				return option?.label || selected[0];
 			}
 			return `${selected.length}個選択中`;
@@ -109,7 +135,17 @@ export const FilterSheet = memo(
 			const selected = form.watch("gender");
 			if (selected.length === 0) return "性別を選択";
 			if (selected.length === 1) {
-				const option = filterOptions.find((opt) => opt.id === selected[0]);
+				const option = genderOptions.find((opt) => opt.id === selected[0]);
+				return option?.label || selected[0];
+			}
+			return `${selected.length}個選択中`;
+		};
+
+		const getSelectedStatuses = () => {
+			const selected = form.watch("status");
+			if (selected.length === 0) return "ステータスを選択";
+			if (selected.length === 1) {
+				const option = statusOptions.find((opt) => opt.id === selected[0]);
 				return option?.label || selected[0];
 			}
 			return `${selected.length}個選択中`;
@@ -161,38 +197,34 @@ export const FilterSheet = memo(
 															該当する成長段階が見つかりません。
 														</CommandEmpty>
 														<CommandGroup>
-															{filterOptions
-																.filter(
-																	(item) => !["オス", "メス"].includes(item.id),
-																)
-																.map((item) => {
-																	const isSelected = form
-																		.watch("growth_stage")
-																		.includes(item.id);
-																	return (
-																		<CommandItem
-																			key={item.id}
-																			value={item.id}
-																			onSelect={() => {
-																				if (isSelected) {
-																					removeGrowthStage(item.id);
-																				} else {
-																					addGrowthStage(item.id);
-																				}
-																			}}
-																		>
-																			<Check
-																				className={classNames(
-																					"mr-2 h-4 w-4",
-																					isSelected
-																						? "opacity-100"
-																						: "opacity-0",
-																				)}
-																			/>
-																			{item.label}
-																		</CommandItem>
-																	);
-																})}
+															{growthStageOptions.map((item) => {
+																const isSelected = form
+																	.watch("growth_stage")
+																	.includes(item.id);
+																return (
+																	<CommandItem
+																		key={item.id}
+																		value={item.id}
+																		onSelect={() => {
+																			if (isSelected) {
+																				removeGrowthStage(item.id);
+																			} else {
+																				addGrowthStage(item.id);
+																			}
+																		}}
+																	>
+																		<Check
+																			className={classNames(
+																				"mr-2 h-4 w-4",
+																				isSelected
+																					? "opacity-100"
+																					: "opacity-0",
+																			)}
+																		/>
+																		{item.label}
+																	</CommandItem>
+																);
+															})}
 														</CommandGroup>
 													</CommandList>
 												</Command>
@@ -202,7 +234,7 @@ export const FilterSheet = memo(
 										{form.watch("growth_stage").length > 0 && (
 											<div className="flex flex-wrap gap-2">
 												{form.watch("growth_stage").map((stage) => {
-													const option = filterOptions.find(
+													const option = growthStageOptions.find(
 														(opt) => opt.id === stage,
 													);
 													return (
@@ -247,38 +279,34 @@ export const FilterSheet = memo(
 															該当する性別が見つかりません。
 														</CommandEmpty>
 														<CommandGroup>
-															{filterOptions
-																.filter((item) =>
-																	["オス", "メス"].includes(item.id),
-																)
-																.map((item) => {
-																	const isSelected = form
-																		.watch("gender")
-																		.includes(item.id);
-																	return (
-																		<CommandItem
-																			key={item.id}
-																			value={item.id}
-																			onSelect={() => {
-																				if (isSelected) {
-																					removeGender(item.id);
-																				} else {
-																					addGender(item.id);
-																				}
-																			}}
-																		>
-																			<Check
-																				className={classNames(
-																					"mr-2 h-4 w-4",
-																					isSelected
-																						? "opacity-100"
-																						: "opacity-0",
-																				)}
-																			/>
-																			{item.label}
-																		</CommandItem>
-																	);
-																})}
+															{genderOptions.map((item) => {
+																const isSelected = form
+																	.watch("gender")
+																	.includes(item.id);
+																return (
+																	<CommandItem
+																		key={item.id}
+																		value={item.id}
+																		onSelect={() => {
+																			if (isSelected) {
+																				removeGender(item.id);
+																			} else {
+																				addGender(item.id);
+																			}
+																		}}
+																	>
+																		<Check
+																			className={classNames(
+																				"mr-2 h-4 w-4",
+																				isSelected
+																					? "opacity-100"
+																					: "opacity-0",
+																			)}
+																		/>
+																		{item.label}
+																	</CommandItem>
+																);
+															})}
 														</CommandGroup>
 													</CommandList>
 												</Command>
@@ -288,7 +316,7 @@ export const FilterSheet = memo(
 										{form.watch("gender").length > 0 && (
 											<div className="flex flex-wrap gap-2">
 												{form.watch("gender").map((gender) => {
-													const option = filterOptions.find(
+													const option = genderOptions.find(
 														(opt) => opt.id === gender,
 													);
 													return (
@@ -301,6 +329,88 @@ export const FilterSheet = memo(
 															<button
 																type="button"
 																onClick={() => removeGender(gender)}
+																className="ml-1 hover:bg-gray-300 rounded-full p-0.5"
+															>
+																<X className="h-3 w-3" />
+															</button>
+														</Badge>
+													);
+												})}
+											</div>
+										)}
+									</div>
+
+									<div className="space-y-3">
+										<h3 className="font-medium text-lg">ステータス</h3>
+										<Popover open={statusOpen} onOpenChange={setStatusOpen}>
+											<PopoverTrigger asChild>
+												<Button
+													variant="outline"
+													aria-expanded={statusOpen}
+													className="w-full justify-between"
+												>
+													{getSelectedStatuses()}
+													<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+												</Button>
+											</PopoverTrigger>
+											<PopoverContent className="w-full p-0">
+												<Command>
+													<CommandInput placeholder="ステータスを検索..." />
+													<CommandList>
+														<CommandEmpty>
+															該当するステータスが見つかりません。
+														</CommandEmpty>
+														<CommandGroup>
+															{statusOptions.map((item) => {
+																const isSelected = form
+																	.watch("status")
+																	.includes(item.id);
+																return (
+																	<CommandItem
+																		key={item.id}
+																		value={item.id}
+																		onSelect={() => {
+																			if (isSelected) {
+																				removeStatus(item.id);
+																			} else {
+																				addStatus(item.id);
+																			}
+																		}}
+																	>
+																		<Check
+																			className={classNames(
+																				"mr-2 h-4 w-4",
+																				isSelected
+																					? "opacity-100"
+																					: "opacity-0",
+																			)}
+																		/>
+																		{item.label}
+																	</CommandItem>
+																);
+															})}
+														</CommandGroup>
+													</CommandList>
+												</Command>
+											</PopoverContent>
+										</Popover>
+
+										{form.watch("status").length > 0 && (
+											<div className="flex flex-wrap gap-2">
+												{form.watch("status").map((status) => {
+													const option = statusOptions.find(
+														(opt) => opt.id === status,
+													);
+													return (
+														<Badge
+															key={status}
+															variant="secondary"
+															className="text-sm"
+														>
+															{option?.label}
+															<button
+																type="button"
+																onClick={() => removeStatus(status)}
 																className="ml-1 hover:bg-gray-300 rounded-full p-0.5"
 															>
 																<X className="h-3 w-3" />

--- a/apps/web/src/features/cattle/list/constants.ts
+++ b/apps/web/src/features/cattle/list/constants.ts
@@ -3,35 +3,24 @@ import { z } from "zod";
 
 export type CattleListItem = GetCattleListResType["results"][0];
 
-export const filterOptions = [
-	{
-		id: "CALF",
-		label: "仔牛",
-	},
-	{
-		id: "GROWING",
-		label: "育成牛",
-	},
-	{
-		id: "FATTENING",
-		label: "肥育牛",
-	},
-	{
-		id: "FIRST_CALVED",
-		label: "初産牛",
-	},
-	{
-		id: "MULTI_PAROUS",
-		label: "経産牛",
-	},
-	{
-		id: "オス",
-		label: "オス",
-	},
-	{
-		id: "メス",
-		label: "メス",
-	},
+export const growthStageOptions = [
+	{ id: "CALF", label: "仔牛" },
+	{ id: "GROWING", label: "育成牛" },
+	{ id: "FATTENING", label: "肥育牛" },
+	{ id: "FIRST_CALVED", label: "初産牛" },
+	{ id: "MULTI_PAROUS", label: "経産牛" },
+] as const;
+
+export const genderOptions = [
+	{ id: "オス", label: "オス" },
+	{ id: "メス", label: "メス" },
+] as const;
+
+export const statusOptions = [
+	{ id: "HEALTHY", label: "健康" },
+	{ id: "PREGNANT", label: "妊娠中" },
+	{ id: "RESTING", label: "休息中" },
+	{ id: "TREATING", label: "治療中" },
 ] as const;
 
 export const sortOptions = [
@@ -43,6 +32,7 @@ export const sortOptions = [
 export const FormSchema = z.object({
 	growth_stage: z.array(z.string()),
 	gender: z.array(z.string()),
+	status: z.array(z.string()),
 });
 
 export type FilterFormData = z.infer<typeof FormSchema>;

--- a/apps/web/src/features/cattle/list/container.tsx
+++ b/apps/web/src/features/cattle/list/container.tsx
@@ -19,6 +19,7 @@ export default async function CattleListContainer({ searchParams }: Props) {
 			? params.growth_stage[0]
 			: params.growth_stage,
 		gender: Array.isArray(params.gender) ? params.gender[0] : params.gender,
+		status: Array.isArray(params.status) ? params.status[0] : params.status,
 	});
 	const cattleList = data.results;
 

--- a/apps/web/src/features/cattle/list/presentational.tsx
+++ b/apps/web/src/features/cattle/list/presentational.tsx
@@ -57,6 +57,12 @@ export function CattleListPresentation({
 			params.delete("gender");
 		}
 
+		if (data.status.length > 0) {
+			params.set("status", data.status.join(","));
+		} else {
+			params.delete("status");
+		}
+
 		router.push(`/cattle?${params.toString()}`);
 	};
 
@@ -64,6 +70,7 @@ export function CattleListPresentation({
 		const params = new URLSearchParams(searchParams.toString());
 		params.delete("growth_stage");
 		params.delete("gender");
+		params.delete("status");
 		router.push(`/cattle?${params.toString()}`);
 	};
 
@@ -100,6 +107,7 @@ export function CattleListPresentation({
 							searchParams.get("growth_stage")?.split(",") || []
 						}
 						initialGender={searchParams.get("gender")?.split(",") || []}
+						initialStatus={searchParams.get("status")?.split(",") || []}
 						onSubmit={handleFilterSubmit}
 						onClear={clearAllFilters}
 					/>

--- a/apps/web/src/services/__tests__/cattleService.test.ts
+++ b/apps/web/src/services/__tests__/cattleService.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api-client", () => ({
+	fetchWithAuth: (cb: (token: string) => Promise<unknown>) => cb("test-token"),
+}));
+vi.mock("@/lib/rpc", () => {
+	const patchMock = vi.fn();
+	return {
+		client: {
+			api: {
+				v1: {
+					cattle: {
+						":id": {
+							status: {
+								$patch: patchMock,
+							},
+						},
+					},
+				},
+			},
+		},
+		patchMock,
+	};
+});
+
+describe("updateCattleStatus", () => {
+	it("calls PATCH with correct parameters", async () => {
+		const { updateCattleStatus } = await import("../cattleService");
+		const { patchMock } = await import("@/lib/rpc");
+		vi.mocked(patchMock).mockResolvedValueOnce(undefined);
+		await updateCattleStatus(1, "HEALTHY", "test");
+		expect(patchMock).toHaveBeenCalledWith(
+			{
+				param: { id: "1" },
+				json: { status: "HEALTHY", reason: "test" },
+			},
+			{ headers: { Authorization: "Bearer test-token" } },
+		);
+	});
+});

--- a/apps/web/src/services/cattleService.ts
+++ b/apps/web/src/services/cattleService.ts
@@ -20,6 +20,7 @@ export type CattleListQueryParams = {
 	search?: string;
 	growth_stage?: string;
 	gender?: string;
+	status?: string;
 };
 
 export async function GetCattleList(
@@ -36,6 +37,7 @@ export async function GetCattleList(
 					search: queryParams.search,
 					growth_stage: queryParams.growth_stage,
 					gender: queryParams.gender,
+					status: queryParams.status,
 				},
 			},
 			{
@@ -181,6 +183,29 @@ export async function UpdateCattleDetailed(
 			{
 				param: { id: id.toString() },
 				json: data,
+			},
+			{
+				headers: {
+					Authorization: `Bearer ${token}`,
+				},
+			},
+		),
+	);
+}
+
+export async function updateCattleStatus(
+	id: number | string,
+	status: "HEALTHY" | "PREGNANT" | "RESTING" | "TREATING",
+	reason?: string,
+): Promise<void> {
+	return fetchWithAuth<void>((token) =>
+		client.api.v1.cattle[":id"].status.$patch(
+			{
+				param: { id: id.toString() },
+				json: {
+					status,
+					...(reason ? { reason } : {}),
+				},
 			},
 			{
 				headers: {


### PR DESCRIPTION
## Summary
- add service for updating cattle status via PATCH API
- show and edit cattle status with dialog in detail header
- allow filtering cattle lists by status

## Testing
- `pnpm -F web test:run`


------
https://chatgpt.com/codex/tasks/task_e_6898421c64a0832998e791c773294d00