### PR TITLE
feat: handle calf-specific data separately from breeding cows

### DIFF
--- a/apps/api/drizzle/migrations/0009_remove_non_cow_breeding.sql
+++ b/apps/api/drizzle/migrations/0009_remove_non_cow_breeding.sql
@@ -1,0 +1,9 @@
+-- Remove breeding records for cattle that are not breeding cows
+DELETE FROM breeding_status
+WHERE cattleId IN (
+    SELECT cattleId FROM cattle WHERE growthStage NOT IN ('FIRST_CALVED','MULTI_PAROUS')
+);
+DELETE FROM breeding_summary
+WHERE cattleId IN (
+    SELECT cattleId FROM cattle WHERE growthStage NOT IN ('FIRST_CALVED','MULTI_PAROUS')
+);

--- a/apps/api/drizzle/migrations/meta/0009_snapshot.json
+++ b/apps/api/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,850 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "6f3c2a50-53cc-419a-b659-be15371200a7",
+	"prevId": "6a56ba52-364e-430c-bdb8-7f824f273f05",
+	"tables": {
+		"bloodline": {
+			"name": "bloodline",
+			"columns": {
+				"bloodlineId": {
+					"name": "bloodlineId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"fatherCattleName": {
+					"name": "fatherCattleName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"motherFatherCattleName": {
+					"name": "motherFatherCattleName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"motherGrandFatherCattleName": {
+					"name": "motherGrandFatherCattleName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"motherGreatGrandFatherCattleName": {
+					"name": "motherGreatGrandFatherCattleName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"bloodline_cattleId_cattle_cattleId_fk": {
+					"name": "bloodline_cattleId_cattle_cattleId_fk",
+					"tableFrom": "bloodline",
+					"tableTo": "cattle",
+					"columnsFrom": ["cattleId"],
+					"columnsTo": ["cattleId"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"breeding_status": {
+			"name": "breeding_status",
+			"columns": {
+				"breedingStatusId": {
+					"name": "breedingStatusId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parity": {
+					"name": "parity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expectedCalvingDate": {
+					"name": "expectedCalvingDate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scheduledPregnancyCheckDate": {
+					"name": "scheduledPregnancyCheckDate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"daysAfterCalving": {
+					"name": "daysAfterCalving",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"daysOpen": {
+					"name": "daysOpen",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pregnancyDays": {
+					"name": "pregnancyDays",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"daysAfterInsemination": {
+					"name": "daysAfterInsemination",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"inseminationCount": {
+					"name": "inseminationCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"breedingMemo": {
+					"name": "breedingMemo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"isDifficultBirth": {
+					"name": "isDifficultBirth",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"breeding_status_cattleId_cattle_cattleId_fk": {
+					"name": "breeding_status_cattleId_cattle_cattleId_fk",
+					"tableFrom": "breeding_status",
+					"tableTo": "cattle",
+					"columnsFrom": ["cattleId"],
+					"columnsTo": ["cattleId"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"breeding_summary": {
+			"name": "breeding_summary",
+			"columns": {
+				"breedingSummaryId": {
+					"name": "breedingSummaryId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"totalInseminationCount": {
+					"name": "totalInseminationCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"averageDaysOpen": {
+					"name": "averageDaysOpen",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"averagePregnancyPeriod": {
+					"name": "averagePregnancyPeriod",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"averageCalvingInterval": {
+					"name": "averageCalvingInterval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"difficultBirthCount": {
+					"name": "difficultBirthCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pregnancyHeadCount": {
+					"name": "pregnancyHeadCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pregnancySuccessRate": {
+					"name": "pregnancySuccessRate",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"breeding_summary_cattleId_cattle_cattleId_fk": {
+					"name": "breeding_summary_cattleId_cattle_cattleId_fk",
+					"tableFrom": "breeding_summary",
+					"tableTo": "cattle",
+					"columnsFrom": ["cattleId"],
+					"columnsTo": ["cattleId"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"cattle": {
+			"name": "cattle",
+			"columns": {
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"ownerUserId": {
+					"name": "ownerUserId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identificationNumber": {
+					"name": "identificationNumber",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"earTagNumber": {
+					"name": "earTagNumber",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"growthStage": {
+					"name": "growthStage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"birthday": {
+					"name": "birthday",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"age": {
+					"name": "age",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"monthsOld": {
+					"name": "monthsOld",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"daysOld": {
+					"name": "daysOld",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"gender": {
+					"name": "gender",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"score": {
+					"name": "score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"breed": {
+					"name": "breed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"producerName": {
+					"name": "producerName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"barn": {
+					"name": "barn",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"breedingValue": {
+					"name": "breedingValue",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cattle_ownerUserId_users_id_fk": {
+					"name": "cattle_ownerUserId_users_id_fk",
+					"tableFrom": "cattle",
+					"tableTo": "users",
+					"columnsFrom": ["ownerUserId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"cattle_status_history": {
+			"name": "cattle_status_history",
+			"columns": {
+				"historyId": {
+					"name": "historyId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"oldStatus": {
+					"name": "oldStatus",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"newStatus": {
+					"name": "newStatus",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"changedAt": {
+					"name": "changedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				},
+				"changedBy": {
+					"name": "changedBy",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cattle_status_history_cattleId_cattle_cattleId_fk": {
+					"name": "cattle_status_history_cattleId_cattle_cattleId_fk",
+					"tableFrom": "cattle_status_history",
+					"tableTo": "cattle",
+					"columnsFrom": ["cattleId"],
+					"columnsTo": ["cattleId"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"cattle_status_history_changedBy_users_id_fk": {
+					"name": "cattle_status_history_changedBy_users_id_fk",
+					"tableFrom": "cattle_status_history",
+					"tableTo": "users",
+					"columnsFrom": ["changedBy"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"events": {
+			"name": "events",
+			"columns": {
+				"eventId": {
+					"name": "eventId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"eventType": {
+					"name": "eventType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"eventDatetime": {
+					"name": "eventDatetime",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(datetime('now', 'utc'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"events_cattleId_cattle_cattleId_fk": {
+					"name": "events_cattleId_cattle_cattleId_fk",
+					"tableFrom": "events",
+					"tableTo": "cattle",
+					"columnsFrom": ["cattleId"],
+					"columnsTo": ["cattleId"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"mother_info": {
+			"name": "mother_info",
+			"columns": {
+				"motherInfoId": {
+					"name": "motherInfoId",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"cattleId": {
+					"name": "cattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"motherCattleId": {
+					"name": "motherCattleId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"motherName": {
+					"name": "motherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"motherIdentificationNumber": {
+					"name": "motherIdentificationNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"motherScore": {
+					"name": "motherScore",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"mother_info_cattleId_cattle_cattleId_fk": {
+					"name": "mother_info_cattleId_cattle_cattleId_fk",
+					"tableFrom": "mother_info",
+					"tableTo": "cattle",
+					"columnsFrom": ["cattleId"],
+					"columnsTo": ["cattleId"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"userName": {
+					"name": "userName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'仮登録ユーザー'"
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"passwordHash": {
+					"name": "passwordHash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_verified": {
+					"name": "is_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"verification_token": {
+					"name": "verification_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_login_at": {
+					"name": "last_login_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'light'"
+				},
+				"google_id": {
+					"name": "google_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"line_id": {
+					"name": "line_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"oauth_provider": {
+					"name": "oauth_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"avatar_url": {
+					"name": "avatar_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(CURRENT_TIMESTAMP)"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(CURRENT_TIMESTAMP)"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "(CURRENT_TIMESTAMP)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"sessions_user_id_users_id_fk": {
+					"name": "sessions_user_id_users_id_fk",
+					"tableFrom": "sessions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {
+			"\"cattle\".\"healthStatus\"": "\"cattle\".\"status\""
+		}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/api/drizzle/migrations/meta/_journal.json
+++ b/apps/api/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1754770566738,
 			"tag": "0008_worthless_vargas",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "6",
+			"when": 1754814306000,
+			"tag": "0009_remove_non_cow_breeding",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/src/routes/cattle.ts
+++ b/apps/api/src/routes/cattle.ts
@@ -11,6 +11,10 @@ import {
 } from "../services/cattleService";
 import type { Bindings } from "../types";
 import {
+	type CreateBreedingCowInput,
+	type CreateCalfInput,
+	type UpdateBreedingCowInput,
+	type UpdateCalfInput,
 	createCattleSchema,
 	searchCattleSchema,
 	updateCattleSchema,
@@ -52,7 +56,9 @@ const app = new Hono<{ Bindings: Bindings }>()
 
 	// 牛を新規登録
 	.post("/", zValidator("json", createCattleSchema), async (c) => {
-		const data = c.req.valid("json");
+		const data = c.req.valid("json") as
+			| CreateCalfInput
+			| CreateBreedingCowInput;
 		const userId = c.get("jwtPayload").userId;
 
 		// ownerUserIdをJWTペイロードから設定
@@ -68,7 +74,9 @@ const app = new Hono<{ Bindings: Bindings }>()
 	// 牛を編集
 	.patch("/:id", zValidator("json", updateCattleSchema), async (c) => {
 		const cattleId = Number.parseInt(c.req.param("id"));
-		const data = c.req.valid("json");
+		const data = c.req.valid("json") as
+			| UpdateCalfInput
+			| UpdateBreedingCowInput;
 		const userId = c.get("jwtPayload").userId;
 
 		// 既存の牛を取得して所有者を確認

--- a/apps/web/src/features/cattle/edit/actions.ts
+++ b/apps/web/src/features/cattle/edit/actions.ts
@@ -3,8 +3,9 @@
 import { createDemoResponse, isDemo } from "@/lib/api-client";
 import { verifyAndGetUserId } from "@/lib/jwt";
 import {
+	type UpdateBreedingCowInput,
+	type UpdateCalfInput,
 	UpdateCattleDetailed,
-	type UpdateCattleInput,
 } from "@/services/cattleService";
 import { parseWithZod } from "@conform-to/zod";
 import { redirect } from "next/navigation";
@@ -38,46 +39,78 @@ export async function updateCattleAction(
 			});
 		}
 
-		// APIに送信するデータを準備
-		const apiData: UpdateCattleInput = {
-			identificationNumber: data.identificationNumber,
-			earTagNumber: data.earTagNumber,
-			name: data.name,
-			gender: data.gender,
-			birthday: data.birthday,
-			growthStage: data.growthStage,
-			breed: data.breed || null,
-			notes: data.notes || null,
-			// 血統情報
-			bloodline: data.bloodline
-				? {
-						fatherCattleName: data.bloodline.fatherCattleName || null,
-						motherFatherCattleName:
-							data.bloodline.motherFatherCattleName || null,
-						motherGrandFatherCattleName:
-							data.bloodline.motherGrandFatherCattleName || null,
-						motherGreatGrandFatherCattleName:
-							data.bloodline.motherGreatGrandFatherCattleName || null,
-					}
-				: undefined,
-			// 繁殖状態（手動入力項目のみ）
-			breedingStatus: data.breedingStatus
-				? {
-						parity: null,
-						expectedCalvingDate:
-							data.breedingStatus.expectedCalvingDate || null,
-						scheduledPregnancyCheckDate:
-							data.breedingStatus.scheduledPregnancyCheckDate || null,
-						daysAfterCalving: null,
-						daysOpen: null,
-						pregnancyDays: null,
-						daysAfterInsemination: null,
-						inseminationCount: null,
-						breedingMemo: data.breedingStatus.breedingMemo || null,
-						isDifficultBirth: data.breedingStatus.isDifficultBirth ?? null,
-					}
-				: undefined,
-		};
+		let apiData: UpdateBreedingCowInput | UpdateCalfInput;
+		if (
+			data.growthStage === "FIRST_CALVED" ||
+			data.growthStage === "MULTI_PAROUS"
+		) {
+			apiData = {
+				identificationNumber: data.identificationNumber,
+				earTagNumber: data.earTagNumber,
+				name: data.name,
+				gender: data.gender,
+				birthday: data.birthday,
+				growthStage: data.growthStage,
+				breed: data.breed || null,
+				notes: data.notes || null,
+				bloodline: data.bloodline
+					? {
+							fatherCattleName: data.bloodline.fatherCattleName || null,
+							motherFatherCattleName:
+								data.bloodline.motherFatherCattleName || null,
+							motherGrandFatherCattleName:
+								data.bloodline.motherGrandFatherCattleName || null,
+							motherGreatGrandFatherCattleName:
+								data.bloodline.motherGreatGrandFatherCattleName || null,
+						}
+					: undefined,
+				breedingStatus: data.breedingStatus
+					? {
+							parity: null,
+							expectedCalvingDate:
+								data.breedingStatus.expectedCalvingDate || null,
+							scheduledPregnancyCheckDate:
+								data.breedingStatus.scheduledPregnancyCheckDate || null,
+							daysAfterCalving: null,
+							daysOpen: null,
+							pregnancyDays: null,
+							daysAfterInsemination: null,
+							inseminationCount: null,
+							breedingMemo: data.breedingStatus.breedingMemo || null,
+							isDifficultBirth: data.breedingStatus.isDifficultBirth ?? null,
+						}
+					: undefined,
+			};
+		} else {
+			apiData = {
+				identificationNumber: data.identificationNumber,
+				earTagNumber: data.earTagNumber,
+				name: data.name,
+				gender: data.gender,
+				birthday: data.birthday,
+				growthStage: data.growthStage,
+				breed: data.breed || null,
+				notes: data.notes || null,
+				bloodline: data.bloodline
+					? {
+							fatherCattleName: data.bloodline.fatherCattleName || null,
+							motherFatherCattleName:
+								data.bloodline.motherFatherCattleName || null,
+							motherGrandFatherCattleName:
+								data.bloodline.motherGrandFatherCattleName || null,
+							motherGreatGrandFatherCattleName:
+								data.bloodline.motherGreatGrandFatherCattleName || null,
+						}
+					: undefined,
+				motherInfo: {
+					motherCattleId: data.motherInfo.motherCattleId,
+					motherName: data.motherInfo.motherName || null,
+					motherIdentificationNumber:
+						data.motherInfo.motherIdentificationNumber || null,
+					motherScore: data.motherInfo.motherScore || null,
+				},
+			};
+		}
 
 		await UpdateCattleDetailed(cattleId, apiData);
 

--- a/apps/web/src/features/cattle/edit/presentational.tsx
+++ b/apps/web/src/features/cattle/edit/presentational.tsx
@@ -176,6 +176,7 @@ const CattleEditPresentation = ({
 	const shouldShowBreedingInfo =
 		growthStage &&
 		(growthStage === "FIRST_CALVED" || growthStage === "MULTI_PAROUS");
+	const shouldShowMotherInfo = growthStage && !shouldShowBreedingInfo;
 
 	return (
 		<div className="container mx-auto px-4 py-8">
@@ -473,6 +474,77 @@ const CattleEditPresentation = ({
 						</div>
 					</div>
 				</div>
+
+				{/* 母情報セクション - 子牛の場合のみ表示 */}
+				{shouldShowMotherInfo && (
+					<div className="border-t pt-6">
+						<h2 className="text-lg font-semibold mb-4">母情報</h2>
+						<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+							<div>
+								<label
+									htmlFor="motherInfo.motherCattleId"
+									className="block text-sm font-medium mb-2"
+								>
+									母牛ID*
+								</label>
+								<input
+									id="motherInfo.motherCattleId"
+									type="number"
+									name="motherInfo.motherCattleId"
+									defaultValue={cattle.motherInfo?.motherCattleId || ""}
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="motherInfo.motherName"
+									className="block text-sm font-medium mb-2"
+								>
+									母牛名
+								</label>
+								<input
+									id="motherInfo.motherName"
+									type="text"
+									name="motherInfo.motherName"
+									defaultValue={cattle.motherInfo?.motherName || ""}
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="motherInfo.motherIdentificationNumber"
+									className="block text-sm font-medium mb-2"
+								>
+									母の個体識別番号
+								</label>
+								<input
+									id="motherInfo.motherIdentificationNumber"
+									type="text"
+									name="motherInfo.motherIdentificationNumber"
+									defaultValue={
+										cattle.motherInfo?.motherIdentificationNumber || ""
+									}
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="motherInfo.motherScore"
+									className="block text-sm font-medium mb-2"
+								>
+									母の得点
+								</label>
+								<input
+									id="motherInfo.motherScore"
+									type="number"
+									name="motherInfo.motherScore"
+									defaultValue={cattle.motherInfo?.motherScore || ""}
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+						</div>
+					</div>
+				)}
 
 				{/* 繁殖情報セクション - 子牛以外の場合のみ表示 */}
 				{shouldShowBreedingInfo && (

--- a/apps/web/src/features/cattle/edit/schema.ts
+++ b/apps/web/src/features/cattle/edit/schema.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// 血統情報のスキーマ
 export const bloodlineSchema = z.object({
 	fatherCattleName: z.string().optional(),
 	motherFatherCattleName: z.string().optional(),
@@ -8,7 +7,13 @@ export const bloodlineSchema = z.object({
 	motherGreatGrandFatherCattleName: z.string().optional(),
 });
 
-// 繁殖状態のスキーマ
+export const motherInfoSchema = z.object({
+	motherCattleId: z.coerce.number().min(1, "母牛IDは必須です"),
+	motherName: z.string().optional(),
+	motherIdentificationNumber: z.string().optional(),
+	motherScore: z.coerce.number().optional(),
+});
+
 export const breedingStatusSchema = z.object({
 	expectedCalvingDate: z.string().optional(),
 	scheduledPregnancyCheckDate: z.string().optional(),
@@ -16,23 +21,32 @@ export const breedingStatusSchema = z.object({
 	isDifficultBirth: z.coerce.boolean().optional(),
 });
 
-// 更新用のスキーマ
-export const updateCattleSchema = z.object({
+const baseSchema = z.object({
 	identificationNumber: z.coerce.number().min(1, "個体識別番号は必須です"),
 	earTagNumber: z.coerce.number().min(1, "耳標番号は必須です"),
 	name: z.string().min(1, "名号は必須です"),
 	gender: z.string().min(1, "性別は必須です"),
 	birthday: z.string().min(1, "生年月日は必須です"),
-	growthStage: z.enum(
-		["CALF", "GROWING", "FATTENING", "FIRST_CALVED", "MULTI_PAROUS"],
-		{
-			required_error: "成長段階は必須です",
-		},
-	),
 	breed: z.string().optional(),
 	notes: z.string().optional(),
-	// 血統情報
 	bloodline: bloodlineSchema.optional(),
-	// 繁殖情報
+});
+
+export const updateCalfSchema = baseSchema.extend({
+	growthStage: z.enum(["CALF", "GROWING", "FATTENING"], {
+		required_error: "成長段階は必須です",
+	}),
+	motherInfo: motherInfoSchema,
+});
+
+export const updateBreedingCowSchema = baseSchema.extend({
+	growthStage: z.enum(["FIRST_CALVED", "MULTI_PAROUS"], {
+		required_error: "成長段階は必須です",
+	}),
 	breedingStatus: breedingStatusSchema.optional(),
 });
+
+export const updateCattleSchema = z.discriminatedUnion("growthStage", [
+	updateCalfSchema,
+	updateBreedingCowSchema,
+]);

--- a/apps/web/src/features/cattle/new/actions.ts
+++ b/apps/web/src/features/cattle/new/actions.ts
@@ -2,7 +2,11 @@
 
 import { createDemoResponse, isDemo } from "@/lib/api-client";
 import { verifyAndGetUserId } from "@/lib/jwt";
-import { CreateCattle, type CreateCattleInput } from "@/services/cattleService";
+import {
+	type CreateBreedingCowInput,
+	type CreateCalfInput,
+	CreateCattle,
+} from "@/services/cattleService";
 import { parseWithZod } from "@conform-to/zod";
 import { redirect } from "next/navigation";
 import { createCattleSchema } from "./schema";
@@ -27,49 +31,79 @@ export async function createCattleAction(
 
 		const data = submission.value;
 
-		// APIに送信するデータを準備
-		const apiData: CreateCattleInput = {
-			identificationNumber: data.identificationNumber,
-			earTagNumber: data.earTagNumber,
-			name: data.name,
-			gender: data.gender,
-			birthday: data.birthday,
-			growthStage: data.growthStage,
-			breed: data.breed || null,
-			notes: data.notes || null,
-			status: "HEALTHY", // デフォルトで健康ステータスを設定
-			// 血統情報
-			bloodline: data.bloodline
-				? {
-						fatherCattleName: data.bloodline.fatherCattleName || null,
-						motherFatherCattleName:
-							data.bloodline.motherFatherCattleName || null,
-						motherGrandFatherCattleName:
-							data.bloodline.motherGrandFatherCattleName || null,
-						motherGreatGrandFatherCattleName:
-							data.bloodline.motherGreatGrandFatherCattleName || null,
-					}
-				: undefined,
-			// 繁殖状態（手動入力項目のみ）
-			breedingStatus: data.breedingStatus
-				? {
-						parity: null,
-						expectedCalvingDate:
-							data.breedingStatus.expectedCalvingDate || null,
-						scheduledPregnancyCheckDate:
-							data.breedingStatus.scheduledPregnancyCheckDate || null,
-						daysAfterCalving: null,
-						daysOpen: null,
-						pregnancyDays: null,
-						daysAfterInsemination: null,
-						inseminationCount: null,
-						breedingMemo: data.breedingStatus.breedingMemo || null,
-						isDifficultBirth: data.breedingStatus.isDifficultBirth ?? null,
-					}
-				: undefined,
-		};
-
-		await CreateCattle(apiData);
+		if (
+			data.growthStage === "FIRST_CALVED" ||
+			data.growthStage === "MULTI_PAROUS"
+		) {
+			const apiData: CreateBreedingCowInput = {
+				identificationNumber: data.identificationNumber,
+				earTagNumber: data.earTagNumber,
+				name: data.name,
+				gender: data.gender,
+				birthday: data.birthday,
+				growthStage: data.growthStage,
+				breed: data.breed || null,
+				notes: data.notes || null,
+				bloodline: data.bloodline
+					? {
+							fatherCattleName: data.bloodline.fatherCattleName || null,
+							motherFatherCattleName:
+								data.bloodline.motherFatherCattleName || null,
+							motherGrandFatherCattleName:
+								data.bloodline.motherGrandFatherCattleName || null,
+							motherGreatGrandFatherCattleName:
+								data.bloodline.motherGreatGrandFatherCattleName || null,
+						}
+					: undefined,
+				breedingStatus: data.breedingStatus
+					? {
+							parity: null,
+							expectedCalvingDate:
+								data.breedingStatus.expectedCalvingDate || null,
+							scheduledPregnancyCheckDate:
+								data.breedingStatus.scheduledPregnancyCheckDate || null,
+							daysAfterCalving: null,
+							daysOpen: null,
+							pregnancyDays: null,
+							daysAfterInsemination: null,
+							inseminationCount: null,
+							breedingMemo: data.breedingStatus.breedingMemo || null,
+							isDifficultBirth: data.breedingStatus.isDifficultBirth ?? null,
+						}
+					: undefined,
+			};
+			await CreateCattle(apiData);
+		} else {
+			const apiData: CreateCalfInput = {
+				identificationNumber: data.identificationNumber,
+				earTagNumber: data.earTagNumber,
+				name: data.name,
+				gender: data.gender,
+				birthday: data.birthday,
+				growthStage: data.growthStage,
+				breed: data.breed || null,
+				notes: data.notes || null,
+				bloodline: data.bloodline
+					? {
+							fatherCattleName: data.bloodline.fatherCattleName || null,
+							motherFatherCattleName:
+								data.bloodline.motherFatherCattleName || null,
+							motherGrandFatherCattleName:
+								data.bloodline.motherGrandFatherCattleName || null,
+							motherGreatGrandFatherCattleName:
+								data.bloodline.motherGreatGrandFatherCattleName || null,
+						}
+					: undefined,
+				motherInfo: {
+					motherCattleId: data.motherInfo.motherCattleId,
+					motherName: data.motherInfo.motherName || null,
+					motherIdentificationNumber:
+						data.motherInfo.motherIdentificationNumber || null,
+					motherScore: data.motherInfo.motherScore || null,
+				},
+			};
+			await CreateCattle(apiData);
+		}
 
 		// 成功時のレスポンス
 		return submission.reply();

--- a/apps/web/src/features/cattle/new/presentational.tsx
+++ b/apps/web/src/features/cattle/new/presentational.tsx
@@ -135,6 +135,7 @@ export function CattleNewPresentation({ error }: CattleNewPresentationProps) {
 	const shouldShowBreedingInfo =
 		growthStage &&
 		(growthStage === "FIRST_CALVED" || growthStage === "MULTI_PAROUS");
+	const shouldShowMotherInfo = growthStage && !shouldShowBreedingInfo;
 
 	return (
 		<div className="container mx-auto px-4 py-8">
@@ -424,6 +425,71 @@ export function CattleNewPresentation({ error }: CattleNewPresentationProps) {
 						</div>
 					</div>
 				</div>
+
+				{/* 母情報セクション - 子牛の場合のみ表示 */}
+				{shouldShowMotherInfo && (
+					<div className="border-t pt-6">
+						<h2 className="text-lg font-semibold mb-4">母情報</h2>
+						<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+							<div>
+								<label
+									htmlFor="motherInfo.motherCattleId"
+									className="block text-sm font-medium mb-2"
+								>
+									母牛ID*
+								</label>
+								<input
+									id="motherInfo.motherCattleId"
+									type="number"
+									name="motherInfo.motherCattleId"
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="motherInfo.motherName"
+									className="block text-sm font-medium mb-2"
+								>
+									母牛名
+								</label>
+								<input
+									id="motherInfo.motherName"
+									type="text"
+									name="motherInfo.motherName"
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="motherInfo.motherIdentificationNumber"
+									className="block text-sm font-medium mb-2"
+								>
+									母の個体識別番号
+								</label>
+								<input
+									id="motherInfo.motherIdentificationNumber"
+									type="text"
+									name="motherInfo.motherIdentificationNumber"
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="motherInfo.motherScore"
+									className="block text-sm font-medium mb-2"
+								>
+									母の得点
+								</label>
+								<input
+									id="motherInfo.motherScore"
+									type="number"
+									name="motherInfo.motherScore"
+									className="w-full rounded-md border border-input bg-background px-3 py-2"
+								/>
+							</div>
+						</div>
+					</div>
+				)}
 
 				{/* 繁殖情報セクション - 子牛以外の場合のみ表示 */}
 				{shouldShowBreedingInfo && (

--- a/apps/web/src/services/cattleService.ts
+++ b/apps/web/src/services/cattleService.ts
@@ -135,21 +135,38 @@ export async function UpdateCattle(
 	);
 }
 
-export type CreateCattleInput = {
+export type CreateCalfInput = {
 	identificationNumber: number;
 	earTagNumber: number;
 	name: string;
 	gender: string;
 	birthday: string;
-	growthStage:
-		| "CALF"
-		| "GROWING"
-		| "FATTENING"
-		| "FIRST_CALVED"
-		| "MULTI_PAROUS";
+	growthStage: "CALF" | "GROWING" | "FATTENING";
 	breed: string | null;
 	notes: string | null;
-	status?: "HEALTHY" | "PREGNANT" | "RESTING" | "TREATING" | "SHIPPED" | "DEAD";
+	bloodline?: {
+		fatherCattleName: string | null;
+		motherFatherCattleName: string | null;
+		motherGrandFatherCattleName: string | null;
+		motherGreatGrandFatherCattleName: string | null;
+	};
+	motherInfo: {
+		motherCattleId: number;
+		motherName: string | null;
+		motherIdentificationNumber: string | null;
+		motherScore: number | null;
+	};
+};
+
+export type CreateBreedingCowInput = {
+	identificationNumber: number;
+	earTagNumber: number;
+	name: string;
+	gender: string;
+	birthday: string;
+	growthStage: "FIRST_CALVED" | "MULTI_PAROUS";
+	breed: string | null;
+	notes: string | null;
 	bloodline?: {
 		fatherCattleName: string | null;
 		motherFatherCattleName: string | null;
@@ -168,18 +185,13 @@ export type CreateCattleInput = {
 		breedingMemo: string | null;
 		isDifficultBirth: boolean | null;
 	};
-	breedingSummary?: {
-		totalInseminationCount: number | null;
-		averageDaysOpen: number | null;
-		averagePregnancyPeriod: number | null;
-		averageCalvingInterval: number | null;
-		difficultBirthCount: number | null;
-		pregnancyHeadCount: number | null;
-		pregnancySuccessRate: number | null;
-	};
 };
 
-export type UpdateCattleInput = CreateCattleInput;
+export type CreateCattleInput = CreateCalfInput | CreateBreedingCowInput;
+
+export type UpdateCalfInput = CreateCalfInput;
+export type UpdateBreedingCowInput = CreateBreedingCowInput;
+export type UpdateCattleInput = UpdateCalfInput | UpdateBreedingCowInput;
 
 export async function CreateCattle(data: CreateCattleInput): Promise<void> {
 	return fetchWithAuth<void>((token) =>


### PR DESCRIPTION
## Summary
- split cattle validators into calf vs breeding cow with mother info
- add mother info repository & service logic to skip breeding data for calves
- adjust API routes, web forms, and services for new schemas
- purge breeding records for non-cows in migration

## Testing
- `pnpm -F api test` *(fails: Database error, expected 400 to be 201, etc.)*
- `pnpm -F web test` *(fails: An update to CattleDetailHeader inside a test was not wrapped in act, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68983c25117c8329b9ea842f47166190