### PR TITLE
feat: add pre-registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ cp .env.example .env.local
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
 - `JWT_SECRET`
+- `RESEND_API_KEY`
+- `MAIL_FROM`
+- `TURNSTILE_SECRET_KEY`
+- `ADMIN_USER`
+- `ADMIN_PASS`
 
 #### Web (apps/web)
 ```bash
@@ -85,6 +90,9 @@ cp .env.example .env.local
 
 必要な環境変数:
 - `NEXT_PUBLIC_API_URL`
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`
+- `ADMIN_USER`
+- `ADMIN_PASS`
 
 ### 4. データベースのセットアップ
 ```bash
@@ -176,6 +184,12 @@ cd apps/api
 pnpm run create-dummy-data:local   # ローカル用
 pnpm run create-dummy-data:remote  # 本番用
 ```
+
+### 事前登録テーブルの初期化
+```bash
+wrangler d1 execute <DB_NAME> --file=apps/api/drizzle/migrations/0010_pre_registration.sql
+```
+Resend の Sender Domain `gyulist.com` を認証し、`RESEND_API_KEY` を設定してください。
 
 ## 🚀 デプロイメント
 

--- a/apps/api/drizzle/migrations/0010_pre_registration.sql
+++ b/apps/api/drizzle/migrations/0010_pre_registration.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS registrations (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  referral_source TEXT,
+  status TEXT NOT NULL,
+  locale TEXT NOT NULL DEFAULT 'ja',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS email_logs (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL,
+  type TEXT NOT NULL,
+  http_status INTEGER,
+  resend_id TEXT,
+  error TEXT,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reg_created_at ON registrations(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_reg_referral_source ON registrations(referral_source);

--- a/apps/api/src/middleware/basicAuth.ts
+++ b/apps/api/src/middleware/basicAuth.ts
@@ -1,0 +1,18 @@
+import type { MiddlewareHandler } from "hono";
+import type { Bindings } from "../types";
+
+export const basicAuth = (): MiddlewareHandler<{ Bindings: Bindings }> => {
+	return async (c, next) => {
+		const auth = c.req.header("authorization") || "";
+		const { ADMIN_USER, ADMIN_PASS } = c.env;
+		const expected = `Basic ${btoa(`${ADMIN_USER}:${ADMIN_PASS}`)}`;
+		if (auth !== expected) {
+			c.header("WWW-Authenticate", 'Basic realm="Restricted"');
+			return c.json(
+				{ ok: false, code: "UNAUTHORIZED", message: "Unauthorized" },
+				401,
+			);
+		}
+		await next();
+	};
+};

--- a/apps/api/src/repositories/registrationRepository.ts
+++ b/apps/api/src/repositories/registrationRepository.ts
@@ -1,0 +1,89 @@
+import type { AnyD1Database } from "drizzle-orm/d1";
+import type { EmailLog, Registration } from "../types";
+
+export async function findRegistrationByEmail(
+	db: AnyD1Database,
+	email: string,
+) {
+	const stmt = db
+		.prepare("SELECT * FROM registrations WHERE email = ?")
+		.bind(email);
+	const res = await stmt.first<Registration>();
+	return res ?? null;
+}
+
+export async function insertRegistration(
+	db: AnyD1Database,
+	registration: Registration,
+) {
+	const stmt = db
+		.prepare(
+			"INSERT INTO registrations (id, email, referral_source, status, locale, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		)
+		.bind(
+			registration.id,
+			registration.email,
+			registration.referral_source,
+			registration.status,
+			registration.locale,
+			registration.created_at,
+			registration.updated_at,
+		);
+	await stmt.run();
+}
+
+export type RegistrationFilters = {
+	q?: string;
+	from?: number;
+	to?: number;
+	source?: string;
+	limit: number;
+	offset: number;
+};
+
+export async function listRegistrations(
+	db: AnyD1Database,
+	filters: RegistrationFilters,
+): Promise<Registration[]> {
+	let sql =
+		"SELECT email, referral_source, created_at FROM registrations WHERE 1=1";
+	const params: (string | number)[] = [];
+	if (filters.q) {
+		sql += " AND email LIKE ?";
+		params.push(`%${filters.q}%`);
+	}
+	if (filters.from) {
+		sql += " AND created_at >= ?";
+		params.push(filters.from);
+	}
+	if (filters.to) {
+		sql += " AND created_at <= ?";
+		params.push(filters.to);
+	}
+	if (filters.source) {
+		sql += " AND referral_source = ?";
+		params.push(filters.source);
+	}
+	sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?";
+	params.push(filters.limit, filters.offset);
+	const stmt = db.prepare(sql).bind(...params);
+	const res = await stmt.all<Registration>();
+	return res.results as Registration[];
+}
+
+export async function insertEmailLog(db: AnyD1Database, log: EmailLog) {
+	const stmt = db
+		.prepare(
+			"INSERT INTO email_logs (id, email, type, http_status, resend_id, error, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		)
+		.bind(
+			log.id,
+			log.email,
+			log.type,
+			log.http_status ?? null,
+			log.resend_id ?? null,
+			log.error ?? null,
+			log.created_at,
+		);
+	await stmt.run();
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -6,17 +6,19 @@ import cattleRoutes from "./cattle";
 import eventsRoutes from "./events";
 import healthRoutes from "./health";
 import oauthRoutes from "./oauth";
+import registrationsRoutes from "./registrations";
 import usersRoutes from "./users";
 
 // biome-ignore format:
 export const createRoutes = (app: Hono<{ Bindings: Bindings }>) => {
 	return app
 		.basePath("/api/v1")
-		.use("*", corsMiddleware)
-		.route("/", healthRoutes)
-		.route("/auth", authRoutes)
-		.route("/oauth", oauthRoutes)
-		.route("/users", usersRoutes)
-		.route("/cattle", cattleRoutes)
-		.route("/events", eventsRoutes);
+                .use("*", corsMiddleware)
+                .route("/", healthRoutes)
+                .route("/", registrationsRoutes)
+                .route("/auth", authRoutes)
+                .route("/oauth", oauthRoutes)
+                .route("/users", usersRoutes)
+                .route("/cattle", cattleRoutes)
+                .route("/events", eventsRoutes);
 };

--- a/apps/api/src/routes/registrations.ts
+++ b/apps/api/src/routes/registrations.ts
@@ -1,0 +1,114 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { basicAuth } from "../middleware/basicAuth";
+import { listRegistrations } from "../repositories/registrationRepository";
+import { preRegister } from "../services/registrationService";
+import type { Bindings } from "../types";
+import {
+	AdminRegistrationsQuerySchema,
+	PreRegisterSchema,
+} from "../validators/registrationValidator";
+
+const app = new Hono<{ Bindings: Bindings }>()
+	.post("/pre-register", zValidator("json", PreRegisterSchema), async (c) => {
+		const data = c.req.valid("json");
+		const result = await preRegister(c.env, data);
+		if ("error" in result) {
+			if (result.error === "TURNSTILE_FAILED") {
+				return c.json(
+					{
+						ok: false,
+						code: "TURNSTILE_FAILED",
+						message: "Turnstile verification failed",
+					},
+					400,
+				);
+			}
+			if (result.error === "RESEND_FAILED") {
+				return c.json(
+					{
+						ok: false,
+						code: "RESEND_FAILED",
+						message: "Email send failed",
+					},
+					502,
+				);
+			}
+			if (result.error === "DB_FAILED") {
+				return c.json(
+					{
+						ok: false,
+						code: "DB_FAILED",
+						message: "Database error",
+					},
+					500,
+				);
+			}
+		}
+		return c.json({ ok: true, alreadyRegistered: result.alreadyRegistered });
+	})
+	.get(
+		"/admin/registrations",
+		basicAuth(),
+		zValidator("query", AdminRegistrationsQuerySchema),
+		async (c) => {
+			const q = c.req.valid("query");
+			const filters = {
+				q: q.q,
+				from: q.from
+					? Math.floor(new Date(q.from).getTime() / 1000)
+					: undefined,
+				to: q.to ? Math.floor(new Date(q.to).getTime() / 1000) : undefined,
+				source: q.source,
+				limit: q.limit ?? 50,
+				offset: q.offset ?? 0,
+			};
+			const results = await listRegistrations(c.env.DB, filters);
+			return c.json({ ok: true, results });
+		},
+	)
+	.get(
+		"/admin/registrations.csv",
+		basicAuth(),
+		zValidator("query", AdminRegistrationsQuerySchema),
+		async (c) => {
+			const q = c.req.valid("query");
+			const filters = {
+				q: q.q,
+				from: q.from
+					? Math.floor(new Date(q.from).getTime() / 1000)
+					: undefined,
+				to: q.to ? Math.floor(new Date(q.to).getTime() / 1000) : undefined,
+				source: q.source,
+				limit: q.limit ?? 1000,
+				offset: q.offset ?? 0,
+			};
+			const results = await listRegistrations(c.env.DB, filters);
+			const rows = [
+				["email", "referral_source", "created_at"],
+				...results.map((r) => [
+					r.email,
+					r.referral_source ?? "",
+					new Date(r.created_at * 1000).toISOString(),
+				]),
+			];
+			const csv = `\uFEFF${rows
+				.map((r) =>
+					r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(","),
+				)
+				.join("\n")}`;
+			const filename = `registrations_${new Date()
+				.toISOString()
+				.slice(0, 10)
+				.replace(/-/g, "")}.csv`;
+			return c.newResponse(csv, {
+				status: 200,
+				headers: {
+					"Content-Type": "text/csv; charset=utf-8",
+					"Content-Disposition": `attachment; filename=${filename}`,
+				},
+			});
+		},
+	);
+
+export default app;

--- a/apps/api/src/services/registrationService.ts
+++ b/apps/api/src/services/registrationService.ts
@@ -1,0 +1,98 @@
+import {
+	findRegistrationByEmail,
+	insertEmailLog,
+	insertRegistration,
+} from "../repositories/registrationRepository";
+import type { Bindings } from "../types";
+import type { PreRegisterInput } from "../validators/registrationValidator";
+
+async function verifyTurnstile(env: Bindings, token: string) {
+	const body = new URLSearchParams({
+		secret: env.TURNSTILE_SECRET_KEY,
+		response: token,
+	});
+	const res = await fetch(
+		"https://challenges.cloudflare.com/turnstile/v0/siteverify",
+		{
+			method: "POST",
+			body,
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		},
+	);
+	const data = await res.json<{ success: boolean; "error-codes"?: string[] }>();
+	return data.success === true;
+}
+
+async function sendCompletedEmail(
+	env: Bindings,
+	email: string,
+	referralSource: string | null,
+) {
+	const res = await fetch("https://api.resend.com/emails", {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${env.RESEND_API_KEY}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			from: env.MAIL_FROM,
+			to: email,
+			subject: "事前登録ありがとうございます",
+			html: `<p>Gyulistへの事前登録が完了しました。</p><p>登録メール: ${email}</p><p>どこで知ったか: ${referralSource ?? ""}</p>`,
+		}),
+	});
+	let resendId: string | undefined;
+	let error: string | undefined;
+	if (res.ok) {
+		const json = await res.json<{ id: string }>();
+		resendId = json.id;
+	} else {
+		error = await res.text();
+		console.error("Resend failed", error);
+	}
+	await insertEmailLog(env.DB, {
+		id: crypto.randomUUID(),
+		email,
+		type: "completed",
+		http_status: res.status,
+		resend_id: resendId,
+		error,
+		created_at: Math.floor(Date.now() / 1000),
+	});
+	if (!res.ok) {
+		throw new Error("RESEND_FAILED");
+	}
+}
+
+export async function preRegister(env: Bindings, data: PreRegisterInput) {
+	const ok = await verifyTurnstile(env, data.turnstileToken);
+	if (!ok) {
+		console.error("Turnstile verification failed", data.email);
+		return { error: "TURNSTILE_FAILED" } as const;
+	}
+	const existing = await findRegistrationByEmail(env.DB, data.email);
+	if (existing) {
+		return { alreadyRegistered: true } as const;
+	}
+	const now = Math.floor(Date.now() / 1000);
+	try {
+		await insertRegistration(env.DB, {
+			id: crypto.randomUUID(),
+			email: data.email,
+			referral_source: data.referralSource || null,
+			status: "confirmed",
+			locale: "ja",
+			created_at: now,
+			updated_at: now,
+		});
+	} catch (e) {
+		console.error("DB insert failed", e);
+		return { error: "DB_FAILED" } as const;
+	}
+	try {
+		await sendCompletedEmail(env, data.email, data.referralSource || null);
+	} catch (e) {
+		return { error: "RESEND_FAILED" } as const;
+	}
+	return { alreadyRegistered: false } as const;
+}

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -7,4 +7,29 @@ export type Bindings = {
 	JWT_SECRET: string;
 	GOOGLE_CLIENT_ID: string;
 	GOOGLE_CLIENT_SECRET: string;
+	RESEND_API_KEY: string;
+	MAIL_FROM: string;
+	TURNSTILE_SECRET_KEY: string;
+	ADMIN_USER: string;
+	ADMIN_PASS: string;
+};
+
+export type Registration = {
+	id: string;
+	email: string;
+	referral_source: string | null;
+	status: string;
+	locale: string;
+	created_at: number;
+	updated_at: number;
+};
+
+export type EmailLog = {
+	id: string;
+	email: string;
+	type: string;
+	http_status?: number | null;
+	resend_id?: string | null;
+	error?: string | null;
+	created_at: number;
 };

--- a/apps/api/src/validators/registrationValidator.ts
+++ b/apps/api/src/validators/registrationValidator.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const PreRegisterSchema = z.object({
+	email: z
+		.string()
+		.email()
+		.transform((v) => v.trim().toLowerCase()),
+	referralSource: z
+		.string()
+		.max(100)
+		.optional()
+		.transform((v) => {
+			const value = v?.trim();
+			return value ? value : null;
+		}),
+	turnstileToken: z.string().min(10),
+});
+
+export type PreRegisterInput = z.infer<typeof PreRegisterSchema>;
+
+export const AdminRegistrationsQuerySchema = z.object({
+	q: z.string().optional(),
+	from: z.string().optional(),
+	to: z.string().optional(),
+	source: z.string().optional(),
+	limit: z.coerce.number().int().positive().max(100).optional(),
+	offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+export type AdminRegistrationsQuery = z.infer<
+	typeof AdminRegistrationsQuerySchema
+>;

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,19 @@
+import { getRequestContext } from "@cloudflare/next-on-pages";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export const config = {
+	matcher: "/admin/:path*",
+};
+
+export function middleware(req: NextRequest) {
+	const auth = req.headers.get("authorization") || "";
+	const { ADMIN_USER, ADMIN_PASS } = getRequestContext().env;
+	const expected = `Basic ${btoa(`${ADMIN_USER}:${ADMIN_PASS}`)}`;
+	if (auth !== expected) {
+		const res = new NextResponse("Unauthorized", { status: 401 });
+		res.headers.set("WWW-Authenticate", 'Basic realm="Restricted"');
+		return res;
+	}
+	return NextResponse.next();
+}

--- a/apps/web/src/app/admin/registrations/page.tsx
+++ b/apps/web/src/app/admin/registrations/page.tsx
@@ -1,0 +1,11 @@
+import AdminRegistrationsContainer from "@/features/admin/registrations/list/container";
+
+export const runtime = "edge";
+
+interface Props {
+	searchParams: { [key: string]: string | string[] | undefined };
+}
+
+export default function AdminRegistrationsPage({ searchParams }: Props) {
+	return <AdminRegistrationsContainer searchParams={searchParams} />;
+}

--- a/apps/web/src/app/pre-register/page.tsx
+++ b/apps/web/src/app/pre-register/page.tsx
@@ -1,0 +1,12 @@
+import PreRegisterFormContainer from "@/features/pre-register/form/container";
+
+export const runtime = "edge";
+
+export default function PreRegisterPage() {
+	return (
+		<main className="p-4">
+			<h1 className="text-xl mb-4">事前登録</h1>
+			<PreRegisterFormContainer />
+		</main>
+	);
+}

--- a/apps/web/src/features/admin/registrations/list/container.tsx
+++ b/apps/web/src/features/admin/registrations/list/container.tsx
@@ -1,0 +1,38 @@
+import { headers } from "next/headers";
+import AdminRegistrationsPresentation from "./presentational";
+
+export const runtime = "edge";
+
+interface Props {
+	searchParams: { [key: string]: string | string[] | undefined };
+}
+
+export default async function AdminRegistrationsContainer({
+	searchParams,
+}: Props) {
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(searchParams)) {
+		if (Array.isArray(value)) {
+			params.set(key, value[0]);
+		} else if (value) {
+			params.set(key, value);
+		}
+	}
+	const auth = headers().get("authorization") || "";
+	const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+	const res = await fetch(
+		`${apiBase}/api/v1/admin/registrations?${params.toString()}`,
+		{
+			headers: { authorization: auth },
+			cache: "no-store",
+		},
+	);
+	const data = await res.json();
+	const registrations = data.results || [];
+	return (
+		<AdminRegistrationsPresentation
+			registrations={registrations}
+			params={params}
+		/>
+	);
+}

--- a/apps/web/src/features/admin/registrations/list/presentational.tsx
+++ b/apps/web/src/features/admin/registrations/list/presentational.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+const sources = ["Twitter/X", "検索", "友人", "ブログ記事", "その他"];
+
+interface Registration {
+	email: string;
+	referral_source: string | null;
+	created_at: number;
+}
+
+interface Props {
+	registrations: Registration[];
+	params: URLSearchParams;
+}
+
+export default function AdminRegistrationsPresentation({
+	registrations,
+	params,
+}: Props) {
+	const router = useRouter();
+	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const form = e.currentTarget;
+		const formData = new FormData(form);
+		const newParams = new URLSearchParams();
+		formData.forEach((value, key) => {
+			if (value) newParams.set(key, String(value));
+		});
+		router.push(`/admin/registrations?${newParams.toString()}`);
+	};
+	const limit = Number(params.get("limit") || "10");
+	const offset = Number(params.get("offset") || "0");
+	const next = () => {
+		params.set("offset", String(offset + limit));
+		router.push(`/admin/registrations?${params.toString()}`);
+	};
+	const prev = () => {
+		params.set("offset", String(Math.max(offset - limit, 0)));
+		router.push(`/admin/registrations?${params.toString()}`);
+	};
+	const csvUrl = `/api/v1/admin/registrations.csv?${params.toString()}`;
+
+	return (
+		<div className="p-4">
+			<form onSubmit={handleSubmit} className="space-y-2 mb-4">
+				<input
+					name="q"
+					placeholder="メール検索"
+					defaultValue={params.get("q") || ""}
+					className="border p-1"
+				/>
+				<input
+					name="from"
+					type="date"
+					defaultValue={params.get("from") || ""}
+					className="border p-1"
+				/>
+				<input
+					name="to"
+					type="date"
+					defaultValue={params.get("to") || ""}
+					className="border p-1"
+				/>
+				<select
+					name="source"
+					defaultValue={params.get("source") || ""}
+					className="border p-1"
+				>
+					<option value="">流入元</option>
+					{sources.map((s) => (
+						<option key={s} value={s}>
+							{s}
+						</option>
+					))}
+				</select>
+				<button type="submit" className="border px-2 py-1">
+					検索
+				</button>
+			</form>
+			<table className="w-full border">
+				<thead>
+					<tr>
+						<th className="border px-2">email</th>
+						<th className="border px-2">referral_source</th>
+						<th className="border px-2">created_at</th>
+					</tr>
+				</thead>
+				<tbody>
+					{registrations.map((r) => (
+						<tr key={r.email}>
+							<td className="border px-2">{r.email}</td>
+							<td className="border px-2">{r.referral_source ?? ""}</td>
+							<td className="border px-2">
+								{new Date(r.created_at * 1000).toLocaleString()}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+			<div className="flex gap-2 mt-2">
+				<button
+					type="button"
+					onClick={prev}
+					className="border px-2 py-1"
+					disabled={offset === 0}
+				>
+					前へ
+				</button>
+				<button type="button" onClick={next} className="border px-2 py-1">
+					次へ
+				</button>
+				<a href={csvUrl} className="border px-2 py-1" download>
+					CSV
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/features/admin/registrations/list/schema.ts
+++ b/apps/web/src/features/admin/registrations/list/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const filterSchema = z.object({
+	q: z.string().optional(),
+	from: z.string().optional(),
+	to: z.string().optional(),
+	source: z.string().optional(),
+	limit: z.coerce.number().optional(),
+	offset: z.coerce.number().optional(),
+});
+
+export type FilterInput = z.infer<typeof filterSchema>;

--- a/apps/web/src/features/pre-register/form/container.tsx
+++ b/apps/web/src/features/pre-register/form/container.tsx
@@ -1,0 +1,7 @@
+import { PreRegisterForm } from "./presentational";
+
+export const runtime = "edge";
+
+export default function PreRegisterFormContainer() {
+	return <PreRegisterForm />;
+}

--- a/apps/web/src/features/pre-register/form/presentational.tsx
+++ b/apps/web/src/features/pre-register/form/presentational.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { preRegisterSchema } from "./schema";
+
+const options = ["Twitter/X", "検索", "友人", "ブログ記事", "その他"];
+
+export function PreRegisterForm() {
+	const [token, setToken] = useState("");
+	const [message, setMessage] = useState("");
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		(window as unknown as { onTurnstile: (t: string) => void }).onTurnstile = (
+			t,
+		) => setToken(t);
+		const script = document.createElement("script");
+		script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+		script.async = true;
+		document.head.appendChild(script);
+	}, []);
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const formData = new FormData(e.currentTarget);
+		const input = {
+			email: String(formData.get("email") || ""),
+			referralSource: String(formData.get("referralSource") || ""),
+			turnstileToken: token,
+		};
+		const parsed = preRegisterSchema.safeParse(input);
+		if (!parsed.success) {
+			setMessage("入力が正しくありません");
+			return;
+		}
+		setLoading(true);
+		const res = await fetch("/api/v1/pre-register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(parsed.data),
+		});
+		const data = await res.json();
+		if (res.ok && data.ok) {
+			if (data.alreadyRegistered) {
+				setMessage("このメールは既に登録されています。");
+			} else {
+				setMessage("登録が完了しました。確認メールをご確認ください。");
+			}
+		} else {
+			setMessage("エラーが発生しました");
+		}
+		setLoading(false);
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4">
+			<div>
+				<label htmlFor="email">メールアドレス</label>
+				<input
+					id="email"
+					name="email"
+					type="email"
+					className="border p-2 w-full"
+					required
+				/>
+			</div>
+			<div>
+				<label htmlFor="referral">どこで知ったか</label>
+				<select
+					id="referral"
+					name="referralSource"
+					className="border p-2 w-full"
+				>
+					<option value="">選択してください</option>
+					{options.map((o) => (
+						<option key={o} value={o}>
+							{o}
+						</option>
+					))}
+				</select>
+			</div>
+			<div
+				className="cf-turnstile"
+				data-sitekey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+				data-callback="onTurnstile"
+			/>
+			<button type="submit" disabled={loading} className="border px-4 py-2">
+				送信
+			</button>
+			{loading && <p>送信中...</p>}
+			{message && <p>{message}</p>}
+		</form>
+	);
+}

--- a/apps/web/src/features/pre-register/form/schema.ts
+++ b/apps/web/src/features/pre-register/form/schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const preRegisterSchema = z.object({
+	email: z
+		.string()
+		.email()
+		.transform((v) => v.trim().toLowerCase()),
+	referralSource: z
+		.string()
+		.max(100)
+		.optional()
+		.transform((v) => {
+			const value = v?.trim();
+			return value ? value : null;
+		}),
+	turnstileToken: z.string().min(10),
+});
+
+export type PreRegisterFormInput = z.infer<typeof preRegisterSchema>;


### PR DESCRIPTION
## Summary
- add D1 tables and API endpoints for pre-registration
- implement landing and admin pages with basic auth and CSV export
- document setup and environment variables

## Testing
- `pnpm -F api test` *(fails: Database error)*
- `pnpm -F web test` *(passes)*


------
https://chatgpt.com/codex/tasks/task_e_6899d7e5e0548329ae02542e9e358e8e