### PR TITLE
feat: add pre-registration form and admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cp .env.example .env.local
 
 必要な環境変数:
 - `NEXT_PUBLIC_API_URL`
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`
 
 ### 4. データベースのセットアップ
 ```bash
@@ -108,6 +109,12 @@ pnpm run dev
 ```
 
 ブラウザで [http://localhost:3000](http://localhost:3000) を開いてアプリケーションを確認できます。
+
+### 事前登録フォームと管理画面
+
+トップページの「正式開始の先行案内」フォームから事前登録できます。Cloudflare Turnstile を利用するため `NEXT_PUBLIC_TURNSTILE_SITE_KEY` を設定してください。
+
+登録内容は `/pre-registers` で確認できます。ユーザー名とパスワードを入力して Basic 認証を通過すると一覧が表示され、検索・期間指定・流入元フィルタ・CSV ダウンロードが利用できます。
 
 ## 📁 プロジェクト構造
 

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -23,7 +23,15 @@
 				// wrangler secret put GOOGLE_CLIENT_ID
 				// wrangler secret put GOOGLE_CLIENT_SECRET
 				// wrangler secret put JWT_SECRET
-			}
+			},
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "gyulist",
+					"database_id": "7caf92b9-b864-48ca-a69a-bdc006b8bf4f",
+					"migrations_dir": "drizzle/migrations"
+				}
+			]
 		}
 	},
 	// "kv_namespaces": [

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -29,20 +29,9 @@ const nextConfig: NextConfig = {
 			"date-fns",
 			"embla-carousel-react",
 		],
-		// ツリーシェイキングの強化
-		turbo: {
-			rules: {
-				"*.svg": {
-					loaders: ["@svgr/webpack"],
-					as: "*.js",
-				},
-			},
-		},
 	},
 	// 圧縮の有効化
 	compress: true,
-	// SWCによる最適化
-	swcMinify: true,
 	// パフォーマンス最適化
 	poweredByHeader: false,
 	generateEtags: false,

--- a/apps/web/src/app/pre-registers/page.tsx
+++ b/apps/web/src/app/pre-registers/page.tsx
@@ -16,11 +16,11 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function Page({
+export default async function Page({
 	searchParams,
 }: {
-	searchParams?: QueryParams;
+	searchParams?: Promise<QueryParams>;
 }) {
-	const params: QueryParams = searchParams ?? {};
+	const params: QueryParams = (await searchParams) ?? {};
 	return <PreRegisterAdmin initialParams={params} />;
 }

--- a/apps/web/src/app/pre-registers/page.tsx
+++ b/apps/web/src/app/pre-registers/page.tsx
@@ -16,11 +16,11 @@ export const metadata: Metadata = {
 	},
 };
 
-export default async function Page({
+export default function Page({
 	searchParams,
 }: {
-	searchParams: Promise<QueryParams>;
+	searchParams?: QueryParams;
 }) {
-	const params = await searchParams;
+	const params: QueryParams = searchParams ?? {};
 	return <PreRegisterAdmin initialParams={params} />;
 }

--- a/apps/web/src/app/pre-registers/page.tsx
+++ b/apps/web/src/app/pre-registers/page.tsx
@@ -1,0 +1,16 @@
+import { PreRegisterAdmin } from "@/features/pre-registers/admin/presentational";
+import type { QueryParams } from "@/features/pre-registers/admin/utils";
+import { headers } from "next/headers";
+
+export const runtime = "edge";
+
+export default async function Page({
+	searchParams,
+}: {
+	searchParams: Promise<QueryParams>;
+}) {
+	const h = headers();
+	h.set("X-Robots-Tag", "noindex");
+	const params = await searchParams;
+	return <PreRegisterAdmin initialParams={params} />;
+}

--- a/apps/web/src/app/pre-registers/page.tsx
+++ b/apps/web/src/app/pre-registers/page.tsx
@@ -1,16 +1,26 @@
 import { PreRegisterAdmin } from "@/features/pre-registers/admin/presentational";
 import type { QueryParams } from "@/features/pre-registers/admin/utils";
-import { headers } from "next/headers";
+import type { Metadata } from "next";
 
 export const runtime = "edge";
+
+export const metadata: Metadata = {
+	robots: {
+		index: false,
+		follow: false,
+		googleBot: {
+			index: false,
+			follow: false,
+			noimageindex: true,
+		},
+	},
+};
 
 export default async function Page({
 	searchParams,
 }: {
 	searchParams: Promise<QueryParams>;
 }) {
-	const h = headers();
-	h.set("X-Robots-Tag", "noindex");
 	const params = await searchParams;
 	return <PreRegisterAdmin initialParams={params} />;
 }

--- a/apps/web/src/components/landing/waitlist/__tests__/email-signup.test.tsx
+++ b/apps/web/src/components/landing/waitlist/__tests__/email-signup.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { EmailSignup } from "../email-signup";
+
+function mockFetch(response: unknown) {
+	return vi.spyOn(global, "fetch").mockResolvedValue(
+		new Response(JSON.stringify(response), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		}),
+	);
+}
+
+describe("EmailSignup", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("validates required and format", async () => {
+		mockFetch({ ok: true });
+		render(<EmailSignup />);
+		const submit = screen.getByRole("button", { name: "登録する" });
+		await userEvent.click(submit);
+		expect(
+			await screen.findByText("無効なメールアドレスです"),
+		).toBeInTheDocument();
+		const email = screen.getByPlaceholderText("メールアドレス");
+		await userEvent.type(email, "invalid");
+		await userEvent.click(submit);
+		expect(
+			await screen.findByText("無効なメールアドレスです"),
+		).toBeInTheDocument();
+	});
+
+	it("submits successfully", async () => {
+		const onSuccess = vi.fn();
+		const fetchMock = mockFetch({ ok: true });
+		render(<EmailSignup onSuccess={onSuccess} />);
+		const email = screen.getByPlaceholderText("メールアドレス");
+		await userEvent.type(email, "test@example.com");
+		const tokenInput = screen.getByTestId("turnstile");
+		fireEvent.input(tokenInput, { target: { value: "token" } });
+		const submit = screen.getByRole("button", { name: "登録する" });
+		await userEvent.click(submit);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(
+			await screen.findByText("登録完了メールを送信しました"),
+		).toBeInTheDocument();
+		expect(onSuccess).toHaveBeenCalled();
+	});
+
+	it("handles duplicate registration", async () => {
+		mockFetch({ ok: true, alreadyRegistered: true });
+		render(<EmailSignup />);
+		const email = screen.getByPlaceholderText("メールアドレス");
+		await userEvent.type(email, "test@example.com");
+		const tokenInput = screen.getByTestId("turnstile");
+		fireEvent.input(tokenInput, { target: { value: "token" } });
+		const submit = screen.getByRole("button", { name: "登録する" });
+		await userEvent.click(submit);
+		expect(await screen.findByText("既に登録済みです")).toBeInTheDocument();
+	});
+
+	it("prevents double submission", async () => {
+		const fetchMock = mockFetch({ ok: true });
+		render(<EmailSignup />);
+		const email = screen.getByPlaceholderText("メールアドレス");
+		await userEvent.type(email, "test@example.com");
+		const tokenInput = screen.getByTestId("turnstile");
+		fireEvent.input(tokenInput, { target: { value: "token" } });
+		const submit = screen.getByRole("button", { name: "登録する" });
+		await Promise.all([userEvent.click(submit), userEvent.click(submit)]);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/components/landing/waitlist/email-signup.tsx
+++ b/apps/web/src/components/landing/waitlist/email-signup.tsx
@@ -1,20 +1,101 @@
-import { redirect } from "next/navigation";
+"use client";
 
-async function submitWaitlist(formData: FormData) {
-	"use server";
+import { Button } from "@/components/ui/button";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { trackWaitlistSignup } from "@/lib/analytics";
+import { preRegister, preRegisterSchema } from "@/services/preRegisterService";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import type { z } from "zod";
 
-	const email = formData.get("email") as string;
-
-	if (!email) {
-		return;
-	}
-
-	// 実運用ではデータベースに保存やメール送信処理を行う
-	// 現在はwaitlistページにリダイレクト
-	redirect(`/waitlist?email=${encodeURIComponent(email)}`);
+interface EmailSignupProps {
+	className?: string;
+	buttonLabel?: string;
+	sources?: string[];
+	onSuccess?: () => void;
 }
 
-export function EmailSignup() {
+const defaultSources = ["Twitter/X", "検索", "友人", "ブログ記事", "その他"];
+
+export function EmailSignup({
+	className,
+	buttonLabel = "登録する",
+	sources = defaultSources,
+	onSuccess,
+}: EmailSignupProps) {
+	const form = useForm<z.infer<typeof preRegisterSchema>>({
+		resolver: zodResolver(preRegisterSchema),
+		defaultValues: {
+			email: "",
+			referralSource: undefined,
+			turnstileToken: "",
+		},
+	});
+
+	useEffect(() => {
+		const script = document.createElement("script");
+		script.src =
+			"https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+		script.async = true;
+		script.onload = () => {
+			window.turnstile?.render("#turnstile", {
+				sitekey: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "",
+				callback: (token: string) => {
+					form.setValue("turnstileToken", token);
+				},
+			});
+		};
+		document.head.appendChild(script);
+		return () => {
+			document.head.removeChild(script);
+		};
+	}, [form]);
+
+	const onSubmit = async (values: z.infer<typeof preRegisterSchema>) => {
+		const res = await preRegister(values);
+		const resultEl = document.getElementById("waitlist-result");
+		if (res.ok) {
+			if (res.alreadyRegistered) {
+				form.setError("email", { message: "既に登録済みです" });
+			} else {
+				trackWaitlistSignup();
+				onSuccess?.();
+				form.reset();
+				if (resultEl) {
+					resultEl.textContent = "登録完了メールを送信しました";
+				}
+			}
+			return;
+		}
+		if (res.code === "VALIDATION_FAILED" || res.code === "TURNSTILE_FAILED") {
+			for (const [key, msg] of Object.entries(res.fieldErrors ?? {})) {
+				form.setError(key as keyof z.infer<typeof preRegisterSchema>, {
+					message: msg,
+				});
+			}
+		} else if (resultEl) {
+			resultEl.textContent = "エラーが発生しました";
+		}
+	};
+
+	const isSubmitting = form.formState.isSubmitting;
+
 	return (
 		<section id="waitlist" className="py-12 md:py-16 bg-blue-50">
 			<div className="container mx-auto px-4 max-w-2xl">
@@ -25,32 +106,93 @@ export function EmailSignup() {
 					<p className="mt-2 text-center text-gray-600">
 						メールを登録すると、先行アクセスや特典のご案内をお送りします。
 					</p>
-					<form
-						action={submitWaitlist}
-						className="mt-6 flex flex-col sm:flex-row gap-3"
-					>
-						<label htmlFor="waitlist-email" className="sr-only">
-							メールアドレス
-						</label>
-						<input
-							id="waitlist-email"
-							name="email"
-							type="email"
-							required
-							inputMode="email"
-							placeholder="メールアドレス"
-							className="flex-1 bg-white border border-gray-300 rounded-full px-5 py-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400"
-						/>
-						<button
-							type="submit"
-							className="inline-flex justify-center items-center bg-primary text-white px-6 py-3 rounded-full font-semibold hover:opacity-95 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400"
-							data-cta="waitlist-submit"
+					<Form {...form}>
+						<form
+							onSubmit={form.handleSubmit(onSubmit)}
+							className="mt-6 flex flex-col sm:flex-row gap-3"
+							aria-live="polite"
 						>
-							登録する
-						</button>
-					</form>
+							<FormField
+								control={form.control}
+								name="email"
+								render={({ field }) => (
+									<FormItem className="flex-1">
+										<FormLabel className="sr-only">メールアドレス</FormLabel>
+										<FormControl>
+											<Input
+												id="waitlist-email"
+												type="email"
+												placeholder="メールアドレス"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="referralSource"
+								render={({ field }) => (
+									<FormItem>
+										<FormControl>
+											<Select
+												onValueChange={field.onChange}
+												defaultValue={field.value}
+											>
+												<SelectTrigger className="w-[140px]">
+													<SelectValue placeholder="流入元" />
+												</SelectTrigger>
+												<SelectContent>
+													{sources.map((src) => (
+														<SelectItem key={src} value={src}>
+															{src}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="turnstileToken"
+								render={({ field }) => (
+									<FormItem className="hidden">
+										<FormControl>
+											<Input type="hidden" {...field} data-testid="turnstile" />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<div id="turnstile" />
+							<Button
+								type="submit"
+								disabled={isSubmitting}
+								className="inline-flex justify-center items-center bg-primary text-white px-6 py-3 rounded-full font-semibold hover:opacity-95 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400"
+								data-cta="waitlist-submit"
+							>
+								{isSubmitting ? "送信中..." : buttonLabel}
+							</Button>
+						</form>
+					</Form>
+					<p id="waitlist-result" className="text-center mt-4 text-sm" />
 				</div>
 			</div>
 		</section>
 	);
+}
+
+declare global {
+	interface Window {
+		turnstile?: {
+			render: (
+				element: string | HTMLElement,
+				options: { sitekey: string; callback: (token: string) => void },
+			) => void;
+		};
+	}
 }

--- a/apps/web/src/features/pre-registers/admin/__tests__/presentational.test.tsx
+++ b/apps/web/src/features/pre-registers/admin/__tests__/presentational.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { PreRegisterAdmin } from "../presentational";
+
+describe("PreRegisterAdmin", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("adds basic auth header and query", async () => {
+		process.env.NEXT_PUBLIC_API_URL = "https://example.com";
+		const fetchMock = vi.spyOn(global, "fetch").mockImplementation(() =>
+			Promise.resolve(
+				new Response(JSON.stringify({ items: [] }), {
+					status: 200,
+					headers: {
+						"Content-Type": "application/json",
+					},
+				}),
+			),
+		);
+		render(<PreRegisterAdmin initialParams={{}} />);
+		await userEvent.type(screen.getByPlaceholderText("ユーザー"), "u");
+		await userEvent.type(screen.getByPlaceholderText("パスワード"), "p");
+		await userEvent.click(screen.getByRole("button", { name: "ログイン" }));
+		await userEvent.type(screen.getByPlaceholderText("メール検索"), "test");
+		await userEvent.click(screen.getByRole("button", { name: "検索" }));
+		expect(fetchMock).toHaveBeenCalled();
+		const calls = fetchMock.mock.calls;
+		const [url, options] = calls[calls.length - 1];
+		expect(url).toContain("q=test");
+		expect(options?.headers?.Authorization).toBe(`Basic ${btoa("u:p")}`);
+	});
+});

--- a/apps/web/src/features/pre-registers/admin/__tests__/utils.test.ts
+++ b/apps/web/src/features/pre-registers/admin/__tests__/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildQuery, downloadCsv, formatDate } from "../utils";
+
+describe("utils", () => {
+	it("builds query string", () => {
+		const q = buildQuery({ q: "test", limit: 10, offset: 20 });
+		expect(q).toBe("q=test&limit=10&offset=20");
+	});
+
+	it("formats date", () => {
+		const d = formatDate("2024-01-15T10:00:00Z");
+		expect(d).toContain("2024");
+		expect(d).toContain("10");
+	});
+
+	it("downloads csv with bom", async () => {
+		const blob = { text: () => Promise.resolve("a,b") } as unknown as Blob;
+		const createObjectURL = vi.fn().mockReturnValue("blob:url");
+		const revoke = vi.fn();
+		const click = vi.fn();
+		const originalURL = global.URL;
+		// @ts-ignore
+		global.URL = { createObjectURL, revokeObjectURL: revoke };
+		vi.spyOn(document, "createElement").mockReturnValue({
+			href: "",
+			download: "",
+			click,
+		} as unknown as HTMLAnchorElement);
+		await downloadCsv(blob, "test.csv");
+		expect(createObjectURL).toHaveBeenCalled();
+		expect(click).toHaveBeenCalled();
+		expect(revoke).toHaveBeenCalled();
+		global.URL = originalURL;
+	});
+});

--- a/apps/web/src/features/pre-registers/admin/presentational.tsx
+++ b/apps/web/src/features/pre-registers/admin/presentational.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { type QueryParams, buildQuery, downloadCsv, formatDate } from "./utils";
+
+interface Props {
+	initialParams: QueryParams;
+}
+
+type Item = {
+	email: string;
+	referral_source: string;
+	created_at: string;
+};
+
+const sources = ["Twitter/X", "検索", "友人", "ブログ記事", "その他"];
+
+export function PreRegisterAdmin({ initialParams }: Props) {
+	const router = useRouter();
+	const [auth, setAuth] = useState<{ user: string; pass: string } | null>(null);
+	const [credentials, setCredentials] = useState({ user: "", pass: "" });
+	const [params, setParams] = useState<QueryParams>(initialParams);
+	const [items, setItems] = useState<Item[]>([]);
+
+	useEffect(() => {
+		if (!auth) return;
+		const query = buildQuery(params);
+		fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/pre-registers?${query}`, {
+			headers: {
+				Authorization: `Basic ${btoa(`${auth.user}:${auth.pass}`)}`,
+			},
+		})
+			.then((res) => res.json())
+			.then((data) => setItems(data.items ?? []));
+	}, [auth, params]);
+
+	const handleLogin = (e: React.FormEvent) => {
+		e.preventDefault();
+		setAuth(credentials);
+	};
+
+	const handleSearch = (e: React.FormEvent) => {
+		e.preventDefault();
+		setParams({ ...params, offset: 0 });
+		router.replace(`?${buildQuery({ ...params, offset: 0 })}`);
+	};
+
+	const handleDownload = async () => {
+		if (!auth) return;
+		const query = buildQuery(params);
+		const res = await fetch(
+			`${process.env.NEXT_PUBLIC_API_URL}/api/v1/pre-registers?${query}`,
+			{
+				headers: {
+					Authorization: `Basic ${btoa(`${auth.user}:${auth.pass}`)}`,
+					Accept: "text/csv",
+				},
+			},
+		);
+		const blob = await res.blob();
+		await downloadCsv(blob, "pre-registers.csv");
+	};
+
+	if (!auth) {
+		return (
+			<form onSubmit={handleLogin} className="max-w-sm mx-auto mt-8 space-y-2">
+				<Input
+					placeholder="ユーザー"
+					value={credentials.user}
+					onChange={(e) =>
+						setCredentials({
+							...credentials,
+							user: e.target.value,
+						})
+					}
+				/>
+				<Input
+					placeholder="パスワード"
+					type="password"
+					value={credentials.pass}
+					onChange={(e) =>
+						setCredentials({
+							...credentials,
+							pass: e.target.value,
+						})
+					}
+				/>
+				<Button type="submit">ログイン</Button>
+			</form>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<form onSubmit={handleSearch} className="flex flex-wrap gap-2 items-end">
+				<Input
+					placeholder="メール検索"
+					value={params.q ?? ""}
+					onChange={(e) => setParams({ ...params, q: e.target.value })}
+				/>
+				<Input
+					type="date"
+					value={params.from ?? ""}
+					onChange={(e) => setParams({ ...params, from: e.target.value })}
+				/>
+				<Input
+					type="date"
+					value={params.to ?? ""}
+					onChange={(e) => setParams({ ...params, to: e.target.value })}
+				/>
+				<Select
+					value={params.source ?? "all"}
+					onValueChange={(v) =>
+						setParams({
+							...params,
+							source: v === "all" ? undefined : v,
+						})
+					}
+				>
+					<SelectTrigger className="w-[140px]">
+						<SelectValue placeholder="流入元" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">全て</SelectItem>
+						{sources.map((s) => (
+							<SelectItem key={s} value={s}>
+								{s}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<Button type="submit">検索</Button>
+				<Button type="button" onClick={handleDownload}>
+					CSV
+				</Button>
+			</form>
+
+			<table className="w-full text-sm border-collapse">
+				<thead>
+					<tr className="bg-gray-100">
+						<th className="border p-2">email</th>
+						<th className="border p-2">referral_source</th>
+						<th className="border p-2">created_at</th>
+					</tr>
+				</thead>
+				<tbody>
+					{items.map((item) => (
+						<tr key={item.email}>
+							<td className="border p-2">{item.email}</td>
+							<td className="border p-2">{item.referral_source}</td>
+							<td className="border p-2">{formatDate(item.created_at)}</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+			<div className="flex gap-2">
+				<Button
+					type="button"
+					disabled={(params.offset ?? 0) === 0}
+					onClick={() => {
+						const newOffset = Math.max(
+							0,
+							(params.offset ?? 0) - (params.limit ?? 20),
+						);
+						setParams({ ...params, offset: newOffset });
+						router.replace(
+							`?${buildQuery({
+								...params,
+								offset: newOffset,
+							})}`,
+						);
+					}}
+				>
+					前へ
+				</Button>
+				<Button
+					type="button"
+					onClick={() => {
+						const newOffset = (params.offset ?? 0) + (params.limit ?? 20);
+						setParams({ ...params, offset: newOffset });
+						router.replace(
+							`?${buildQuery({
+								...params,
+								offset: newOffset,
+							})}`,
+						);
+					}}
+				>
+					次へ
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/features/pre-registers/admin/presentational.tsx
+++ b/apps/web/src/features/pre-registers/admin/presentational.tsx
@@ -40,7 +40,7 @@ export function PreRegisterAdmin({ initialParams }: Props) {
 				Authorization: `Basic ${btoa(`${auth.user}:${auth.pass}`)}`,
 			},
 		})
-			.then((res) => res.json())
+			.then((res) => res.json<{ items?: Item[] }>())
 			.then((data) => setItems(data.items ?? []));
 	}, [auth, params]);
 

--- a/apps/web/src/features/pre-registers/admin/utils.ts
+++ b/apps/web/src/features/pre-registers/admin/utils.ts
@@ -1,0 +1,34 @@
+export type QueryParams = {
+	q?: string;
+	from?: string;
+	to?: string;
+	source?: string;
+	limit?: number;
+	offset?: number;
+};
+
+export function buildQuery(params: QueryParams): string {
+	const search = new URLSearchParams();
+	for (const [key, value] of Object.entries(params)) {
+		if (value !== undefined && value !== "") {
+			search.set(key, String(value));
+		}
+	}
+	return search.toString();
+}
+
+export function formatDate(iso: string): string {
+	return new Date(iso).toLocaleString();
+}
+
+export async function downloadCsv(blob: Blob, filename: string) {
+	const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+	const text = await blob.text();
+	const csvBlob = new Blob([bom, text], { type: "text/csv" });
+	const url = URL.createObjectURL(csvBlob);
+	const a = document.createElement("a");
+	a.href = url;
+	a.download = filename;
+	a.click();
+	URL.revokeObjectURL(url);
+}

--- a/apps/web/src/services/preRegisterService.ts
+++ b/apps/web/src/services/preRegisterService.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const preRegisterSchema = z.object({
+	email: z
+		.string({ required_error: "必須項目です" })
+		.trim()
+		.toLowerCase()
+		.email("無効なメールアドレスです"),
+	referralSource: z.string().optional(),
+	turnstileToken: z.string({ required_error: "必須項目です" }),
+});
+
+export type PreRegisterInput = z.infer<typeof preRegisterSchema>;
+
+export type PreRegisterSuccess = {
+	ok: true;
+	alreadyRegistered?: boolean;
+};
+
+export type PreRegisterError = {
+	ok: false;
+	code: string;
+	fieldErrors?: Record<string, string>;
+};
+
+export type PreRegisterResponse = PreRegisterSuccess | PreRegisterError;
+
+export async function preRegister(
+	data: PreRegisterInput,
+): Promise<PreRegisterResponse> {
+	const res = await fetch(
+		`${process.env.NEXT_PUBLIC_API_URL}/api/v1/pre-register`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(data),
+		},
+	);
+	const json = (await res.json()) as PreRegisterResponse;
+	return json;
+}


### PR DESCRIPTION
## Summary
- replace waitlist section with validated pre-registration form
- add admin page to browse and export registrations
- document environment variables for waitlist features

## Testing
- `pnpm -F web test:run`


------
https://chatgpt.com/codex/tasks/task_e_689a0898e8d083298d8ee09785c36bb1